### PR TITLE
Create Apple-inspired responsive landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# productos
+# Productos
+
+Landing page inspirada en el home de apple.com que replica la estructura principal de
+productos con estilos responsivos.
+
+## Requisitos
+
+No se necesitan dependencias ni instalaciones adicionales. Los estilos se cargan desde un
+archivo CSS local y fuentes web hospedadas en CDN públicos.
+
+## Cómo ver la página
+
+1. Clona este repositorio o descarga el código.
+2. Abre el archivo [`index.html`](./index.html) directamente en tu navegador favorito.
+3. Asegúrate de contar con conexión a Internet si deseas que la tipografía "SF Pro Display"
+   se cargue desde el CDN indicado.
+
+## Recursos
+
+- Imágenes vectoriales optimizadas en la carpeta [`assets/`](./assets/).
+- Estilos principales en [`styles.css`](./styles.css) utilizando CSS moderno (flexbox, grid y
+  media queries).
+- Interactividad ligera en [`script.js`](./script.js) para animaciones al hacer scroll y menú
+  responsive.
+
+## Limitaciones
+
+- Este sitio es únicamente una recreación de referencia sin contenido oficial de Apple.
+- Las imágenes son ilustraciones propias generadas en formato SVG.
+- Algunos enlaces del diseño redirigen a `#` porque no existen páginas de destino reales.

--- a/assets/airpods.svg
+++ b/assets/airpods.svg
@@ -1,0 +1,8 @@
+<svg width="600" height="500" viewBox="0 0 600 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="140" y="160" width="320" height="220" rx="48" fill="#F5F5F7" stroke="#D1D1D6" stroke-width="8" />
+  <rect x="220" y="80" width="60" height="200" rx="30" fill="#FFFFFF" stroke="#D1D1D6" stroke-width="6" />
+  <rect x="320" y="80" width="60" height="200" rx="30" fill="#FFFFFF" stroke="#D1D1D6" stroke-width="6" />
+  <circle cx="250" cy="104" r="12" fill="#A3A3A8" />
+  <circle cx="350" cy="104" r="12" fill="#A3A3A8" />
+  <text x="50%" y="420" text-anchor="middle" fill="#1F1F1F" font-family="'SF Pro Display', 'Helvetica Neue', Arial" font-size="40" font-weight="600">AirPods Pro</text>
+</svg>

--- a/assets/ipad.svg
+++ b/assets/ipad.svg
@@ -1,0 +1,6 @@
+<svg width="800" height="600" viewBox="0 0 800 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="140" y="60" width="520" height="440" rx="48" fill="#111" stroke="#2C2C2E" stroke-width="8" />
+  <rect x="190" y="120" width="420" height="320" rx="32" fill="#1C1C1E" />
+  <circle cx="400" cy="520" r="16" fill="#3A3A3C" />
+  <text x="50%" y="300" text-anchor="middle" fill="#F5F5F7" font-family="'SF Pro Display', 'Helvetica Neue', Arial" font-size="48" font-weight="600">iPad Pro</text>
+</svg>

--- a/assets/iphone-hero.svg
+++ b/assets/iphone-hero.svg
@@ -1,0 +1,16 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#111" />
+      <stop offset="100%" stop-color="#1f1f1f" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" rx="80" />
+  <g transform="translate(450,120)">
+    <rect x="120" y="60" width="220" height="520" rx="60" fill="#0A0A0A" stroke="#3A3A3C" stroke-width="4" />
+    <rect x="166" y="108" width="128" height="388" rx="36" fill="#0" stroke="#1F1F1F" stroke-width="2" />
+    <circle cx="230" cy="96" r="8" fill="#444" />
+    <rect x="210" y="520" width="40" height="16" rx="8" fill="#2C2C2E" />
+  </g>
+  <text x="50%" y="120" text-anchor="middle" fill="#F5F5F7" font-family="'SF Pro Display', 'Helvetica Neue', Arial" font-size="64" font-weight="600">iPhone Experience</text>
+</svg>

--- a/assets/macbook.svg
+++ b/assets/macbook.svg
@@ -1,0 +1,7 @@
+<svg width="800" height="450" viewBox="0 0 800 450" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="80" y="40" width="640" height="360" rx="32" fill="#111" stroke="#2F2F31" stroke-width="6" />
+  <rect x="120" y="80" width="560" height="280" rx="16" fill="#1F1F1F" />
+  <rect x="60" y="400" width="680" height="24" rx="12" fill="#C7C7CC" />
+  <rect x="280" y="410" width="240" height="10" rx="5" fill="#E5E5EA" />
+  <text x="50%" y="210" text-anchor="middle" fill="#F5F5F7" font-family="'SF Pro Display', 'Helvetica Neue', Arial" font-size="48" font-weight="600">MacBook Air</text>
+</svg>

--- a/assets/music.svg
+++ b/assets/music.svg
@@ -1,0 +1,6 @@
+<svg width="600" height="400" viewBox="0 0 600 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="80" y="80" width="440" height="240" rx="32" fill="#FA2C55" />
+  <path d="M260 140V256C260 274.225 244.225 290 226 290C207.775 290 192 274.225 192 256C192 237.775 207.775 222 226 222C229.962 222 233.736 222.674 237.2 223.944V140H260Z" fill="#fff" />
+  <path d="M360 120V236C360 254.225 344.225 270 326 270C307.775 270 292 254.225 292 236C292 217.775 307.775 202 326 202C329.962 202 333.736 202.674 337.2 203.944V120H360Z" fill="#fff" />
+  <text x="50%" y="340" text-anchor="middle" fill="#fff" font-family="'SF Pro Display', 'Helvetica Neue', Arial" font-size="36" font-weight="600">Apple Music</text>
+</svg>

--- a/assets/watch.svg
+++ b/assets/watch.svg
@@ -1,0 +1,7 @@
+<svg width="600" height="600" viewBox="0 0 600 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="180" y="120" width="240" height="360" rx="60" fill="#111" stroke="#2C2C2E" stroke-width="10" />
+  <rect x="210" y="180" width="180" height="240" rx="40" fill="#1C1C1E" />
+  <rect x="172" y="180" width="48" height="240" rx="24" fill="#2C2C2E" />
+  <rect x="380" y="180" width="48" height="240" rx="24" fill="#2C2C2E" />
+  <text x="50%" y="350" text-anchor="middle" fill="#F5F5F7" font-family="'SF Pro Display', 'Helvetica Neue', Arial" font-size="40" font-weight="600">Apple Watch</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Productos Apple · Inspirado en apple.com</title>
+    <meta
+      name="description"
+      content="Demo inspirado en apple.com con productos destacados y diseño responsive"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/svg+xml" href="assets/iphone-hero.svg" />
+  </head>
+  <body>
+    <header class="global-header">
+      <div class="nav-container">
+        <a class="brand" href="#inicio" aria-label="Apple"></a>
+        <nav id="primary-navigation" class="primary-nav" aria-label="Principal">
+          <ul>
+            <li><a href="#iphone">iPhone</a></li>
+            <li><a href="#mac">Mac</a></li>
+            <li><a href="#ipad">iPad</a></li>
+            <li><a href="#watch">Watch</a></li>
+            <li><a href="#airpods">AirPods</a></li>
+            <li><a href="#servicios">Servicios</a></li>
+            <li><a href="#support">Soporte</a></li>
+          </ul>
+        </nav>
+        <button
+          class="nav-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="primary-navigation"
+          aria-label="Abrir menú"
+        >
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="inicio">
+      <section id="iphone" class="hero animate-on-scroll" data-animate="fade-up">
+        <div class="hero-content">
+          <p class="eyebrow">Nuevo</p>
+          <h1>iPhone 15 Pro</h1>
+          <p class="lede">
+            Titanio. Chip A17 Pro. Botón de Acción personalizable. Una experiencia creada
+            para deslumbrar.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="#comprar">Comprar</a>
+            <a class="button ghost" href="#mas">Más información</a>
+          </div>
+        </div>
+        <picture class="hero-image">
+          <img src="assets/iphone-hero.svg" alt="Ilustración de iPhone" loading="lazy" />
+        </picture>
+      </section>
+
+      <section id="mac" class="product-grid animate-on-scroll" data-animate="fade-in">
+        <article class="product-card dark">
+          <div class="product-copy">
+            <p class="eyebrow">Potencia y ligereza</p>
+            <h2>MacBook Air</h2>
+            <p>
+              Chip M2, batería para todo el día y una pantalla Liquid Retina de 13.6 pulgadas
+              dentro de un diseño silencioso y ultra delgado.
+            </p>
+            <a class="link" href="#">Más información &rsaquo;</a>
+          </div>
+          <img src="assets/macbook.svg" alt="Ilustración de MacBook" loading="lazy" />
+        </article>
+        <article class="product-card light">
+          <div class="product-copy">
+            <p class="eyebrow">Dibuja, diseña, crea</p>
+            <h2>iPad Pro</h2>
+            <p>
+              El poder del chip M2, compatibilidad con Apple Pencil y la pantalla más
+              avanzada en un iPad.
+            </p>
+            <a class="link" href="#">Comprar &rsaquo;</a>
+          </div>
+          <img src="assets/ipad.svg" alt="Ilustración de iPad" loading="lazy" />
+        </article>
+      </section>
+
+      <section id="watch" class="callout animate-on-scroll" data-animate="fade-up">
+        <div class="callout-content">
+          <p class="eyebrow">Siempre contigo</p>
+          <h2>Apple Watch Series 9</h2>
+          <p>
+            Controla tu salud, mantente conectado y descubre un nuevo gesto mágico con el
+            chip S9 SiP.
+          </p>
+          <div class="callout-actions">
+            <a class="button primary" href="#">Personalizar</a>
+            <a class="button ghost" href="#">Explorar correas</a>
+          </div>
+        </div>
+        <img src="assets/watch.svg" alt="Ilustración de Apple Watch" loading="lazy" />
+      </section>
+
+      <section id="airpods" class="product-highlight animate-on-scroll" data-animate="fade-in">
+        <div class="product-highlight-media">
+          <img src="assets/airpods.svg" alt="Ilustración de AirPods" loading="lazy" />
+        </div>
+        <div class="product-highlight-copy">
+          <p class="eyebrow">Sonido envolvente</p>
+          <h2>AirPods Pro</h2>
+          <p>
+            Audio espacial personalizado, cancelación activa de ruido mejorada y una batería
+            de larga duración en un diseño ligero.
+          </p>
+          <a class="link" href="#">Ver especificaciones &rsaquo;</a>
+        </div>
+      </section>
+
+      <section id="servicios" class="services animate-on-scroll" data-animate="fade-up">
+        <h2>Entretenimiento Apple</h2>
+        <div class="services-grid">
+          <article class="service-card">
+            <img src="assets/music.svg" alt="Logotipo de Apple Music" loading="lazy" />
+            <h3>Apple Music</h3>
+            <p>Más de 100 millones de canciones y audio espacial en todos tus dispositivos.</p>
+            <a class="link" href="#">Prueba gratuita &rsaquo;</a>
+          </article>
+          <article class="service-card">
+            <div class="service-icon" aria-hidden="true">tv+</div>
+            <h3>Apple TV+</h3>
+            <p>Series y películas Apple Original con historias que solo Apple puede contar.</p>
+            <a class="link" href="#">Ver ahora &rsaquo;</a>
+          </article>
+          <article class="service-card">
+            <div class="service-icon" aria-hidden="true">arcade</div>
+            <h3>Apple Arcade</h3>
+            <p>Más de 200 juegos sin anuncios ni compras dentro de la app.</p>
+            <a class="link" href="#">Descubrir juegos &rsaquo;</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="comprar" class="cta animate-on-scroll" data-animate="fade-in">
+        <h2>Compra de forma personalizada</h2>
+        <p>
+          Obtén ayuda para elegir el producto ideal, comparar financiamiento y recibirlo con
+          entrega rápida y gratuita.
+        </p>
+        <a class="button primary" href="#">Habla con un especialista</a>
+      </section>
+    </main>
+
+    <footer id="support" class="global-footer">
+      <div class="footer-columns">
+        <section>
+          <h3>Explorar</h3>
+          <ul>
+            <li><a href="#iphone">iPhone</a></li>
+            <li><a href="#mac">Mac</a></li>
+            <li><a href="#ipad">iPad</a></li>
+            <li><a href="#watch">Apple Watch</a></li>
+            <li><a href="#airpods">AirPods</a></li>
+          </ul>
+        </section>
+        <section>
+          <h3>Servicios</h3>
+          <ul>
+            <li><a href="#servicios">Apple Music</a></li>
+            <li><a href="#servicios">Apple TV+</a></li>
+            <li><a href="#servicios">Apple Arcade</a></li>
+          </ul>
+        </section>
+        <section>
+          <h3>Soporte</h3>
+          <ul>
+            <li><a href="#">Centro de ayuda</a></li>
+            <li><a href="#">Garantía</a></li>
+            <li><a href="#">Privacidad</a></li>
+          </ul>
+        </section>
+      </div>
+      <p class="legal">&copy; <span id="year"></span> Sitio demo inspirado en Apple. Todos los derechos reservados.</p>
+    </footer>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,42 @@
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+      }
+    });
+  },
+  {
+    threshold: 0.3,
+    rootMargin: '0px 0px -10% 0px',
+  }
+);
+
+document.querySelectorAll('.animate-on-scroll').forEach((element) => {
+  observer.observe(element);
+});
+
+const navToggle = document.querySelector('.nav-toggle');
+const primaryNav = document.querySelector('#primary-navigation');
+
+if (navToggle && primaryNav) {
+  navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    primaryNav.classList.toggle('open');
+  });
+
+  primaryNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      if (window.innerWidth <= 1024) {
+        navToggle.setAttribute('aria-expanded', 'false');
+        primaryNav.classList.remove('open');
+      }
+    });
+  });
+}
+
+const yearElement = document.querySelector('#year');
+if (yearElement) {
+  yearElement.textContent = new Date().getFullYear().toString();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,568 @@
+/* Tipografías y variables */
+@font-face {
+  font-family: 'SF Pro Display';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://fonts.cdnfonts.com/s/59243/SFPRODISPLAYREGULAR.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'SF Pro Display';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url('https://fonts.cdnfonts.com/s/59243/SFPRODISPLAYSEMIBOLD.woff') format('woff');
+}
+
+:root {
+  color-scheme: light dark;
+  --color-background: #f5f5f7;
+  --color-surface: #ffffff;
+  --color-surface-dark: #1d1d1f;
+  --color-text: #1d1d1f;
+  --color-text-inverse: #f5f5f7;
+  --color-muted: #6e6e73;
+  --color-link: #0071e3;
+  --color-link-dark: #2997ff;
+  --radius-large: 36px;
+  --radius-medium: 26px;
+  --radius-small: 18px;
+  --max-content: 1300px;
+  --space-xxl: clamp(4rem, 6vw, 7rem);
+  --space-xl: clamp(3rem, 5vw, 5rem);
+  --space-lg: clamp(2.5rem, 3vw, 4rem);
+  --space-md: clamp(1.5rem, 2vw, 2.5rem);
+  --space-sm: 1rem;
+  --space-xs: 0.75rem;
+  font-family: 'SF Pro Display', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.global-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: rgba(245, 245, 247, 0.8);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.nav-container {
+  margin: 0 auto;
+  max-width: var(--max-content);
+  padding: 0 var(--space-sm);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 48px;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.brand {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.primary-nav ul {
+  list-style: none;
+  display: flex;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a {
+  color: var(--color-text);
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus {
+  opacity: 1;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-xs);
+  border-radius: 50%;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  margin: 4px 0;
+  background-color: var(--color-text);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+main {
+  display: grid;
+  gap: var(--space-xxl);
+  margin: 0 auto;
+  padding: var(--space-xxl) var(--space-sm) var(--space-xl);
+  max-width: var(--max-content);
+}
+
+.hero {
+  background: radial-gradient(circle at top, #111 0%, #000 60%, #050505 100%);
+  color: var(--color-text-inverse);
+  border-radius: var(--radius-large);
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: center;
+  padding: clamp(3rem, 7vw, 6rem);
+  gap: var(--space-lg);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 45%);
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.hero-content h1 {
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  margin: 0;
+}
+
+.lede {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.2vw, 1.6rem);
+  color: rgba(245, 245, 247, 0.78);
+  line-height: 1.5;
+}
+
+.hero-actions {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 980px;
+  padding: 0.65rem 1.8rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background-color: var(--color-link);
+  color: var(--color-text-inverse);
+}
+
+.button.primary:hover {
+  box-shadow: 0 8px 16px rgba(0, 113, 227, 0.4);
+  transform: translateY(-1px);
+}
+
+.button.ghost {
+  background-color: transparent;
+  border-color: rgba(245, 245, 247, 0.5);
+  color: var(--color-text-inverse);
+}
+
+.button.ghost:hover {
+  border-color: rgba(245, 245, 247, 0.8);
+  transform: translateY(-1px);
+}
+
+.hero-image {
+  position: relative;
+  z-index: 1;
+  justify-self: end;
+}
+
+.hero-image img {
+  width: min(420px, 100%);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+
+.product-card {
+  border-radius: var(--radius-medium);
+  padding: var(--space-xl);
+  display: grid;
+  gap: var(--space-lg);
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.product-card.dark {
+  background-color: var(--color-surface-dark);
+  color: var(--color-text-inverse);
+}
+
+.product-card.light {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.06);
+}
+
+.product-card img {
+  width: min(360px, 100%);
+  justify-self: end;
+}
+
+.product-copy {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.product-copy h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.8rem);
+}
+
+.product-copy p {
+  margin: 0;
+  color: inherit;
+  line-height: 1.6;
+}
+
+.link {
+  color: var(--color-link-dark);
+  font-weight: 600;
+}
+
+.callout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+  align-items: center;
+  border-radius: var(--radius-large);
+  padding: var(--space-xl);
+  background: linear-gradient(135deg, #0b0b0d, #17171a 60%, #050506 100%);
+  color: var(--color-text-inverse);
+}
+
+.callout img {
+  justify-self: end;
+  width: min(320px, 100%);
+}
+
+.callout-content {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.callout-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.product-highlight {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+  align-items: center;
+  border-radius: var(--radius-medium);
+  background-color: var(--color-surface);
+  padding: var(--space-xl);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.06);
+}
+
+.product-highlight-copy {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.services {
+  text-align: center;
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.services-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+
+.service-card {
+  padding: var(--space-lg);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.06);
+  display: grid;
+  gap: var(--space-sm);
+  align-items: start;
+}
+
+.service-card img {
+  width: 120px;
+  margin: 0 auto;
+}
+
+.service-icon {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #fa2c55;
+}
+
+.cta {
+  text-align: center;
+  padding: var(--space-xl);
+  border-radius: var(--radius-medium);
+  background-color: #f2f2f2;
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.global-footer {
+  background-color: #f5f5f7;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  padding: var(--space-xl) var(--space-sm);
+}
+
+.footer-columns {
+  max-width: var(--max-content);
+  margin: 0 auto var(--space-lg);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+
+.footer-columns h3 {
+  margin-top: 0;
+  margin-bottom: var(--space-sm);
+  font-size: 1rem;
+}
+
+.footer-columns ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer-columns a {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.legal {
+  text-align: center;
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+/* Animaciones */
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.animate-on-scroll.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+[data-animate='fade-in'].is-visible {
+  transform: translateY(0);
+}
+
+[data-animate='fade-up'] {
+  transform: translateY(60px);
+}
+
+[data-animate='fade-up'].is-visible {
+  transform: translateY(0);
+}
+
+@media (max-width: 1024px) {
+  .primary-nav {
+    position: fixed;
+    inset: 0;
+    top: 48px;
+    background: rgba(0, 0, 0, 0.85);
+    padding: var(--space-lg) var(--space-md);
+    transform: translateY(-100%);
+    transition: transform 0.3s ease;
+  }
+
+  .primary-nav.open {
+    transform: translateY(0);
+  }
+
+  .primary-nav ul {
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .primary-nav a {
+    color: var(--color-text-inverse);
+    font-size: 1.2rem;
+    opacity: 1;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .nav-toggle[aria-expanded='true'] span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .nav-toggle[aria-expanded='true'] span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .nav-toggle[aria-expanded='true'] span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+
+  .hero,
+  .product-grid,
+  .callout,
+  .product-highlight {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-image,
+  .product-card img,
+  .callout img,
+  .product-highlight-media {
+    justify-self: center;
+  }
+
+  .product-card,
+  .callout,
+  .product-highlight {
+    text-align: left;
+  }
+
+  .services-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .footer-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .nav-container {
+    height: 56px;
+  }
+
+  main {
+    padding: var(--space-xl) var(--space-sm);
+  }
+
+  .hero,
+  .callout,
+  .product-highlight,
+  .product-card,
+  .service-card,
+  .cta {
+    padding: var(--space-lg);
+  }
+
+  .product-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .services-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .animate-on-scroll {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- build an Apple-style landing page with hero, product highlights, services, CTA, and footer sections in `index.html`
- add typography, layout, animation, and responsive behavior with a dedicated `styles.css`
- provide lightweight interactivity with `script.js`, SVG assets for featured products, and README setup guidance

## Testing
- Manual verification in Chromium at desktop viewport

------
https://chatgpt.com/codex/tasks/task_e_68d61bdbd024832e9b9f80683215530a