### PR TITLE
Adjust mobile navigation contrast on tablets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -453,7 +453,9 @@ main {
     position: fixed;
     inset: 0;
     top: 48px;
-    background: rgba(0, 0, 0, 0.85);
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
     padding: var(--space-lg) var(--space-md);
     transform: translateY(-100%);
     opacity: 0;
@@ -476,7 +478,7 @@ main {
   }
 
   .primary-nav a {
-    color: var(--color-text-inverse);
+    color: var(--color-text);
     font-size: 1.2rem;
     opacity: 1;
   }


### PR DESCRIPTION
## Summary
- switch the tablet/mobile navigation panel to use the light surface color with matching text
- add a subtle shadow to separate the fixed panel from the dark hero backdrop
- align link colors within the open navigation panel with the standard text color for readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6230a21fc832eb7735cd01d4961ad