### PR TITLE
Use solid header background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -82,9 +82,15 @@ a:focus {
   position: sticky;
   top: 0;
   z-index: 100;
-  background-color: rgba(245, 245, 247, 0.8);
+  background-color: var(--color-surface);
   backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+@media (prefers-color-scheme: dark) {
+  .global-header {
+    background-color: var(--color-surface-dark);
+  }
 }
 
 .nav-container {


### PR DESCRIPTION
## Summary
- switch the global header to use the solid surface background color
- add a dark mode override to keep contrast when prefers-color-scheme is dark

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d6c01c484c832ea175d7dae92a6afc