### PR TITLE
Flatten card layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,34 +30,23 @@ body {
 
 .shell {
   width: min(100%, 480px);
-  padding: 24px;
+  margin: 0 auto;
+}
+
+main.shell {
+  padding: 40px 36px;
 }
 
 .card {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-large);
-  padding: 40px 36px;
-  box-shadow: var(--shadow-soft);
   position: relative;
-  overflow: hidden;
-}
-
-.card::before {
-  content: "";
-  position: absolute;
-  inset: -120px -140px auto auto;
-  width: 320px;
-  height: 320px;
-  background: radial-gradient(circle, rgba(0, 87, 255, 0.2), transparent 65%);
-  pointer-events: none;
-  z-index: 0;
 }
 
 .card__header {
   position: relative;
   z-index: 1;
   text-align: center;
-  margin-bottom: 32px;
+  margin: 0;
+  padding-bottom: 32px;
 }
 
 .card__header h1 {


### PR DESCRIPTION
## Summary
- remove the card background styling and decorative overlay for a flat presentation
- move the surrounding padding to the main shell container and adjust the header spacing to align content on the page background

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d835fc512c832ea9727d2de9538570