### PR TITLE
Update button and input styling to neutral palette

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -129,13 +129,13 @@ input[type="text"] {
   font-size: 1rem;
   transition: border-color 0.3s var(--transition-base),
     box-shadow 0.3s var(--transition-base);
-  background-color: #f8fafc;
+  background-color: #ffffff;
 }
 
 input:focus {
   outline: none;
-  border-color: rgba(0, 87, 255, 0.6);
-  box-shadow: 0 0 0 4px rgba(0, 87, 255, 0.1);
+  border-color: rgba(107, 114, 128, 0.6);
+  box-shadow: 0 0 0 4px rgba(107, 114, 128, 0.15);
 }
 
 .btn {
@@ -151,24 +151,30 @@ input:focus {
 }
 
 .btn--primary {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-  box-shadow: 0 12px 24px -16px rgba(0, 87, 255, 0.6);
-}
-
-.btn--primary:disabled {
-  opacity: 0.65;
-  cursor: not-allowed;
-  box-shadow: none;
+  background: #111111;
+  color: #ffffff;
+  box-shadow: 0 12px 24px -16px rgba(17, 17, 17, 0.4);
 }
 
 .btn--primary:hover:not(:disabled) {
   transform: translateY(-1px);
+  background: #1f2933;
+}
+
+.btn--primary:disabled {
+  background: #4b5563;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .btn--secondary {
-  background: rgba(0, 87, 255, 0.08);
-  color: var(--color-primary);
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.btn--secondary:hover:not(:disabled) {
+  background: #d1d5db;
 }
 
 .btn--secondary:disabled {
@@ -178,7 +184,13 @@ input:focus {
 
 .btn--ghost {
   background: transparent;
-  color: var(--color-text-secondary);
+  color: #6b7280;
+  border: 1px solid #e5e7eb;
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: rgba(229, 231, 235, 0.4);
+  color: #374151;
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- replace the primary button gradient with a solid near-black background and updated states
- shift secondary and ghost buttons to neutral gray tones instead of relying on the primary color
- set text inputs to white backgrounds with gray focus rings for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8376ee4c0832e9d4e30a2365454f5