### PR TITLE
Style card header with gradient title

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,9 +50,35 @@ main.shell {
 }
 
 .card__header h1 {
+  position: relative;
+  display: inline-block;
   margin: 0 0 12px;
+  padding: 12px 24px 8px;
   font-size: clamp(1.5rem, 2vw + 1rem, 2.2rem);
   font-weight: 700;
+  font-style: italic;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  line-height: 1.1;
+  background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 45%, #38bdf8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 18px 28px rgba(15, 23, 42, 0.25);
+}
+
+.card__header h1::before {
+  content: "ADMIN";
+  position: absolute;
+  top: -0.85em;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.4em;
+  padding: 0 4px;
+  color: #facc15;
+  text-transform: uppercase;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.25));
 }
 
 .card__header p {


### PR DESCRIPTION
## Summary
- update the card header title with italic uppercase gradient text and shadowing
- add an ADMIN pseudo-element badge positioned above the Clientes label for contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d882a5be10832ea4113ede93c65b12