### PR TITLE
Add embedded dashboard view after verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,9 @@
             </form>
           </section>
         </div>
+        <section class="dashboard" data-dashboard hidden>
+          <iframe data-dashboard-frame src="" loading="lazy"></iframe>
+        </section>
       </section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ const state = {
 };
 
 const selectors = {
+  stepper: document.querySelector("[data-stepper]"),
   steps: document.querySelectorAll("[data-step]"),
   emailForm: document.getElementById("email-form"),
   emailInput: document.getElementById("email"),
@@ -29,7 +30,9 @@ const selectors = {
   passwordTitle: document.getElementById("password-title"),
   passwordDescription: document.getElementById("password-description"),
   currentEmail: document.querySelectorAll(".current-email"),
-  actionButtons: document.querySelectorAll('[data-action="back"]')
+  actionButtons: document.querySelectorAll('[data-action="back"]'),
+  dashboard: document.querySelector("[data-dashboard]"),
+  dashboardFrame: document.querySelector("[data-dashboard-frame]")
 };
 
 function showStep(stepName) {
@@ -46,6 +49,22 @@ function showStep(stepName) {
   }
   if (stepName === "verification") {
     selectors.verificationInput.focus({ preventScroll: true });
+  }
+}
+
+function showDashboard() {
+  const stepper = document.querySelector("[data-stepper]");
+  if (stepper) {
+    stepper.hidden = true;
+  }
+
+  if (selectors.dashboard) {
+    selectors.dashboard.hidden = false;
+  }
+
+  if (selectors.dashboardFrame && !selectors.dashboardFrame.src) {
+    selectors.dashboardFrame.src =
+      "https://raw.githubusercontent.com/iamwrely/Admin-Clientes/refs/heads/main/index.html";
   }
 }
 
@@ -241,6 +260,7 @@ async function handleVerificationSubmit(event) {
 
   setFeedback(selectors.feedback.verification, "");
   setFeedback(selectors.feedback.verificationSuccess, "¡Listo! Tu identidad ha sido verificada.", "success");
+  showDashboard();
   selectors.verificationForm.querySelector("button[type='submit']").disabled = true;
   selectors.resendButton.disabled = true;
   clearInterval(state.resendTimer);

--- a/styles.css
+++ b/styles.css
@@ -92,6 +92,34 @@ main.shell {
   min-height: 320px;
 }
 
+[data-stepper][hidden] {
+  display: none;
+}
+
+[data-dashboard][hidden] {
+  display: none;
+}
+
+.dashboard {
+  position: relative;
+  min-height: 320px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.32);
+}
+
+.dashboard iframe,
+.dashboard [data-dashboard-frame] {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: transparent;
+}
+
 .step {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- add a dashboard section to the card layout to host the remote admin view
- update the client script to toggle the dashboard after successful verification and load the remote HTML
- style the dashboard container so it fills the card and hides the stepper when active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8852f0368832e802e8443a37595ed