### PR TITLE
Add backend proxy API for Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Optional: comma-separated list of allowed origins for CORS, e.g. https://tu-app.com,https://admin.tu-app.com
+ALLOWED_ORIGINS=
+# Optional: server port
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ contraseña y verificación) y compatibilidad con acceso mediante Google Identit
 Todos los valores configurables se definen en `window.APP_CONFIG` dentro de
 [`index.html`](./index.html). Actualiza los siguientes campos según tu entorno:
 
+- `apiBaseUrl`: URL base del backend protegido que expone los endpoints `/auth/*`,
+  `/clients` y `/services`. Por defecto la interfaz usa `/api` (ideal cuando se
+  sirve detrás de un proxy o plataforma serverless).
 - `googleClientId`: Client ID generado en Google Cloud Console para Google Identity Services.
 - `googleCallbackEndpoint`: Endpoint en tu backend que recibirá el `credential` devuelto por
   Google. Debe validar y crear/iniciar sesión en la cuenta.
@@ -26,6 +29,35 @@ Todos los valores configurables se definen en `window.APP_CONFIG` dentro de
 > **Nota:** Si no defines los endpoints anteriores, la aplicación utilizará datos simulados en
 > memoria para validar correos y generará códigos de verificación ficticios solo con fines de
 > demostración.
+
+## Backend API con Supabase
+
+El repositorio incluye un backend minimalista en [`api/server.js`](./api/server.js) que actúa como
+capa intermedia entre la interfaz y Supabase. Este servicio:
+
+- Administra el inicio/cierre de sesión y la recuperación de contraseña sin exponer claves.
+- Expone endpoints REST (`/clients` y `/services`) para listar/crear/actualizar/eliminar registros.
+- Utiliza la clave `service_role` desde variables de entorno seguras.
+- Evita que claves sensibles aparezcan en el código compilado; sólo se leen desde el entorno del servidor.
+
+### Configuración de variables de entorno
+
+1. Copia el archivo `.env.example` a `.env` y completa los valores:
+   - `SUPABASE_URL`: URL de tu proyecto Supabase.
+   - `SUPABASE_SERVICE_ROLE_KEY`: clave `service_role` (mantenerla privada, no debe exponerse en el
+     frontend).
+   - `ALLOWED_ORIGINS`: (opcional) lista separada por comas de orígenes autorizados para CORS.
+   - `PORT`: (opcional) puerto local para el servidor Express.
+
+2. Instala las dependencias y levanta el backend:
+
+   ```bash
+   npm install
+   npm start
+   ```
+
+3. Asegúrate de servir la interfaz (por ejemplo con `python -m http.server 8000`) y de que
+   `apiBaseUrl` apunte al backend (por ejemplo `http://localhost:3000/api`).
 
 ## Cómo ejecutar la página
 

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,321 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import { createClient } from '@supabase/supabase-js';
+
+const {
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  PORT = 3000,
+  ALLOWED_ORIGINS
+} = process.env;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.warn('[server] Missing Supabase configuration. Please set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.');
+}
+
+function createSupabaseClient() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Supabase credentials are not configured');
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false
+    }
+  });
+}
+
+async function getUserFromRequest(req) {
+  const authHeader = req.headers.authorization || '';
+  const [, token] = authHeader.split(' ');
+  if (!token) {
+    return null;
+  }
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error) {
+    console.error('[auth] getUser error', error);
+    return null;
+  }
+  return data?.user || null;
+}
+
+function authMiddleware() {
+  return async (req, res, next) => {
+    try {
+      const user = await getUserFromRequest(req);
+      if (!user) {
+        return res.status(401).json({ error: 'No autorizado' });
+      }
+      req.user = user;
+      next();
+    } catch (error) {
+      console.error('[auth] middleware error', error);
+      res.status(401).json({ error: 'No autorizado' });
+    }
+  };
+}
+
+const app = express();
+
+const corsOrigins = (ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+app.use(cors({
+  origin: corsOrigins.length ? corsOrigins : true,
+  credentials: true
+}));
+app.use(express.json());
+
+app.get('/api/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.post('/api/auth/sign-in', async (req, res) => {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Correo y contraseña son obligatorios.' });
+  }
+  try {
+    const supabase = createSupabaseClient();
+    let { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      const { data: signUpData, error: signUpError } = await supabase.auth.signUp({ email, password });
+      if (signUpError) {
+        return res.status(signUpError.status || 400).json({ error: signUpError.message || 'No se pudo registrar.' });
+      }
+      if (!signUpData.session) {
+        ({ data, error } = await supabase.auth.signInWithPassword({ email, password }));
+      } else {
+        data = signUpData;
+        error = null;
+      }
+    }
+    if (error) {
+      return res.status(error.status || 400).json({ error: error.message || 'No se pudo acceder.' });
+    }
+    const session = data.session;
+    if (!session) {
+      return res.status(400).json({ error: 'No se pudo obtener la sesión.' });
+    }
+    res.json({ user: data.user, session: {
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+      expires_at: session.expires_at
+    }});
+  } catch (error) {
+    console.error('[auth] sign-in error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.post('/api/auth/sign-out', authMiddleware(), async (req, res) => {
+  try {
+    const supabase = createSupabaseClient();
+    await supabase.auth.admin.signOutUser(req.user.id);
+  } catch (error) {
+    console.error('[auth] sign-out error', error);
+    // Continue even if revocation fails
+  }
+  res.json({ ok: true });
+});
+
+app.get('/api/auth/session', authMiddleware(), (req, res) => {
+  res.json({ user: req.user });
+});
+
+app.post('/api/auth/reset-password', async (req, res) => {
+  const { email, redirectTo } = req.body || {};
+  if (!email) {
+    return res.status(400).json({ error: 'Correo es obligatorio.' });
+  }
+  try {
+    const supabase = createSupabaseClient();
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: redirectTo || SUPABASE_URL
+    });
+    if (error) {
+      return res.status(error.status || 400).json({ error: error.message || 'No se pudo enviar el correo.' });
+    }
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[auth] reset password error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.get('/api/clients', authMiddleware(), async (req, res) => {
+  try {
+    const supabase = createSupabaseClient();
+    const { data, error } = await supabase
+      .from('clients')
+      .select('*')
+      .eq('user_id', req.user.id)
+      .order('nombre', { ascending: true });
+    if (error) {
+      return res.status(400).json({ error: error.message || 'No se pudieron obtener los clientes.' });
+    }
+    res.json({ items: data || [] });
+  } catch (error) {
+    console.error('[clients] list error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.post('/api/clients', authMiddleware(), async (req, res) => {
+  try {
+    const supabase = createSupabaseClient();
+    const payload = { ...req.body, user_id: req.user.id };
+    delete payload.id;
+    const { data, error } = await supabase
+      .from('clients')
+      .insert(payload)
+      .select()
+      .single();
+    if (error) {
+      return res.status(400).json({ error: error.message || 'No se pudo crear el cliente.' });
+    }
+    res.json({ item: data });
+  } catch (error) {
+    console.error('[clients] create error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.put('/api/clients/:id', authMiddleware(), async (req, res) => {
+  const { id } = req.params;
+  try {
+    const supabase = createSupabaseClient();
+    const payload = { ...req.body, user_id: req.user.id };
+    const { data, error } = await supabase
+      .from('clients')
+      .update(payload)
+      .eq('id', id)
+      .eq('user_id', req.user.id)
+      .select()
+      .single();
+    if (error) {
+      return res.status(400).json({ error: error.message || 'No se pudo actualizar el cliente.' });
+    }
+    res.json({ item: data });
+  } catch (error) {
+    console.error('[clients] update error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.put('/api/clients/bulk', authMiddleware(), async (req, res) => {
+  const { items } = req.body || {};
+  if (!Array.isArray(items)) {
+    return res.status(400).json({ error: 'Se esperaba una lista de clientes.' });
+  }
+  try {
+    const supabase = createSupabaseClient();
+    const rows = items.map((item) => ({ ...item, user_id: req.user.id }));
+    const { error } = await supabase
+      .from('clients')
+      .upsert(rows, { onConflict: 'id' });
+    if (error) {
+      return res.status(400).json({ error: error.message || 'No se pudieron guardar los clientes.' });
+    }
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[clients] bulk error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.delete('/api/clients/:id', authMiddleware(), async (req, res) => {
+  const { id } = req.params;
+  try {
+    const supabase = createSupabaseClient();
+    const { error } = await supabase
+      .from('clients')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', req.user.id);
+    if (error) {
+      return res.status(400).json({ error: error.message || 'No se pudo eliminar el cliente.' });
+    }
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('[clients] delete error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.get('/api/services', authMiddleware(), async (req, res) => {
+  try {
+    const supabase = createSupabaseClient();
+    const { data, error } = await supabase
+      .from('services')
+      .select('name')
+      .eq('user_id', req.user.id)
+      .order('name');
+    if (error) {
+      return res.status(400).json({ error: error.message || 'No se pudieron obtener los servicios.' });
+    }
+    res.json({ items: (data || []).map((row) => row.name) });
+  } catch (error) {
+    console.error('[services] list error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.put('/api/services', authMiddleware(), async (req, res) => {
+  const { items } = req.body || {};
+  if (!Array.isArray(items)) {
+    return res.status(400).json({ error: 'Se esperaba una lista de servicios.' });
+  }
+  const desired = Array.from(new Set(items.filter(Boolean)));
+  try {
+    const supabase = createSupabaseClient();
+    const { data: current, error: currentError } = await supabase
+      .from('services')
+      .select('name')
+      .eq('user_id', req.user.id);
+    if (currentError) {
+      return res.status(400).json({ error: currentError.message || 'No se pudieron sincronizar los servicios.' });
+    }
+    const currentSet = new Set((current || []).map((row) => row.name));
+    const desiredSet = new Set(desired);
+
+    const toDelete = [...currentSet].filter((name) => !desiredSet.has(name));
+    if (toDelete.length) {
+      const { error } = await supabase
+        .from('services')
+        .delete()
+        .in('name', toDelete)
+        .eq('user_id', req.user.id);
+      if (error) {
+        return res.status(400).json({ error: error.message || 'No se pudieron eliminar servicios.' });
+      }
+    }
+
+    const toInsert = [...desiredSet].filter((name) => !currentSet.has(name));
+    if (toInsert.length) {
+      const { error } = await supabase
+        .from('services')
+        .insert(toInsert.map((name) => ({ user_id: req.user.id, name })));
+      if (error) {
+        return res.status(400).json({ error: error.message || 'No se pudieron agregar servicios.' });
+      }
+    }
+
+    res.json({ items: desired });
+  } catch (error) {
+    console.error('[services] update error', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'No encontrado' });
+});
+
+app.listen(PORT, () => {
+  console.log(`[server] Listening on port ${PORT}`);
+});

--- a/index.html
+++ b/index.html
@@ -633,14 +633,66 @@
     </div>
   </div>
 
-  <!-- Supabase JS -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
-
 <script>
-/* ====== CONFIG Supabase ====== */
-const SUPABASE_URL = 'https://dlumywskboedejmeejvp.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRsdW15d3NrYm9lZGVqbWVlanZwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg0Nzk0ODMsImV4cCI6MjA3NDA1NTQ4M30.Ty7b0T6qVneREsH8vKObhpXm5d6wbfXRkA2cFeMzphA';
-const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+/* ====== CONFIG API ====== */
+const API_BASE_URL = ((window.APP_CONFIG?.apiBaseUrl) || '/api').replace(/\/$/, '');
+const SESSION_STORAGE_KEY = 'cloud_session_v1';
+
+function readStoredSession(){
+  try{
+    const raw = localStorage.getItem(SESSION_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  }catch{
+    return null;
+  }
+}
+
+function persistSession(session){
+  if(!session || !session.access_token){
+    return clearStoredSession();
+  }
+  try{
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+  }catch(err){
+    console.warn('No se pudo almacenar la sesión en localStorage', err);
+  }
+  return session;
+}
+
+function clearStoredSession(){
+  try{ localStorage.removeItem(SESSION_STORAGE_KEY); }catch{}
+  return null;
+}
+
+function getStoredAccessToken(){
+  return readStoredSession()?.access_token || null;
+}
+
+async function apiFetch(path,{ method='GET', body, headers={}, silent401=false }={}){
+  const finalHeaders = { ...headers };
+  const token = getStoredAccessToken();
+  if(token){ finalHeaders.Authorization = `Bearer ${token}`; }
+  let payload;
+  if(body !== undefined){
+    finalHeaders['Content-Type'] = 'application/json';
+    payload = JSON.stringify(body);
+  }
+  const response = await fetch(`${API_BASE_URL}${path}`, { method, headers: finalHeaders, body: payload });
+  if(response.status === 401){
+    if(!silent401) handleUnauthorized();
+    const error = new Error('No autorizado');
+    error.code = 'unauthorized';
+    throw error;
+  }
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+  if(!response.ok){
+    const error = new Error(data?.error || 'Error en la solicitud');
+    error.code = data?.code || 'request_failed';
+    throw error;
+  }
+  return data;
+}
 
 /* ===== helpers y refs ===== */
 const $=s=>document.querySelector(s);
@@ -1111,15 +1163,60 @@ function saveLocalClients(){
   }catch{}
 }
 
-/* ====== AUTH (Supabase) ====== */
+/* ====== AUTH (API backend) ====== */
 let currentUser = null;
-sb.auth.onAuthStateChange((_e, session)=>{
-  currentUser = session?.user || null;
+let authInitPromise = null;
+
+function updateUserState(user){
+  currentUser = user;
   authUpdateUI();
-  syncLocalServicesToCloudIfEmpty().finally(()=>{
-    renderServicios().then(renderTabla);
-  });
-});
+  (async()=>{
+    try{
+      if(user){ await syncLocalServicesToCloudIfEmpty(); }
+    }catch(err){
+      console.error(err);
+    }finally{
+      await renderServicios();
+      await renderTabla();
+    }
+  })();
+}
+
+function handleUnauthorized(){
+  const hadUser = !!currentUser;
+  clearStoredSession();
+  updateUserState(null);
+  authInitPromise = Promise.resolve(null);
+  if(hadUser){ toast('Tu sesión expiró. Vuelve a iniciar sesión.'); }
+}
+
+async function fetchSessionUser(){
+  const token = getStoredAccessToken();
+  if(!token){
+    updateUserState(null);
+    return null;
+  }
+  try{
+    const data = await apiFetch('/auth/session', { method:'GET', silent401:true });
+    const user = data?.user || null;
+    updateUserState(user);
+    return user;
+  }catch(error){
+    if(error.code === 'unauthorized'){
+      clearStoredSession();
+      updateUserState(null);
+    }else{
+      console.error(error);
+    }
+    return null;
+  }
+}
+
+function ensureAuthInitialized(){
+  if(!authInitPromise){ authInitPromise = fetchSessionUser(); }
+  return authInitPromise;
+}
+
 function authUpdateUI(){
   const badge = document.getElementById('userInfo');
   const btnAuthOpen = document.getElementById('btnAuthOpen');
@@ -1160,15 +1257,17 @@ toggleAuthPass?.addEventListener('click', ()=>{
 
 // sign-in/up unificado
 async function autoSignInOrUp(email, password) {
-  let { error } = await sb.auth.signInWithPassword({ email, password });
-  if (!error) return { ok: true };
-  const { data, error: eUp } = await sb.auth.signUp({ email, password });
-  if (eUp) return { ok: false, message: eUp.message };
-  if (!data.session) {
-    const { error: eIn2 } = await sb.auth.signInWithPassword({ email, password });
-    if (eIn2) return { ok: false, message: eIn2.message };
+  try{
+    const payload = await apiFetch('/auth/sign-in', { method:'POST', body:{ email, password } });
+    if(payload?.session){ persistSession(payload.session); }
+    if(payload?.user){
+      updateUserState(payload.user);
+      authInitPromise = Promise.resolve(payload.user);
+    }
+    return { ok: true };
+  }catch(error){
+    return { ok: false, message: error.message };
   }
-  return { ok: true };
 }
 btnAuthSubmit?.addEventListener('click', async () => {
   const email = (authEmailEl.value || '').trim();
@@ -1183,19 +1282,33 @@ btnAuthSubmit?.addEventListener('click', async () => {
   }catch(err){ authErrorEl.textContent = err.message || 'Error inesperado.'; }
   finally{ btnAuthSubmit.disabled = false; btnAuthSubmit.textContent = 'Continuar'; }
 });
-document.getElementById('btnLogout')?.addEventListener('click', async ()=>{ await sb.auth.signOut(); });
+document.getElementById('btnLogout')?.addEventListener('click', async ()=>{
+  try{
+    await apiFetch('/auth/sign-out', { method:'POST' });
+  }catch(err){
+    console.warn('No se pudo cerrar sesión remotamente', err);
+  }finally{
+    clearStoredSession();
+    updateUserState(null);
+    authInitPromise = Promise.resolve(null);
+  }
+});
 
 // reset pass
 btnForgot?.addEventListener('click', async ()=>{
   const email = (authEmailEl.value||'').trim();
   authErrorEl.style.color = 'var(--danger)'; authErrorEl.textContent = '';
   if(!email){ authErrorEl.textContent = 'Escribe tu correo arriba para enviarte el enlace.'; return; }
-  const { error } = await sb.auth.resetPasswordForEmail(email, { redirectTo: location.origin + location.pathname });
-  if(error){ authErrorEl.textContent = error.message || 'No se pudo enviar el correo de recuperación.'; return; }
-  authErrorEl.style.color = 'var(--success)'; authErrorEl.textContent = 'Te enviamos un correo para restablecer tu contraseña.';
+  try{
+    await apiFetch('/auth/reset-password', { method:'POST', body:{ email, redirectTo: location.origin + location.pathname } });
+    authErrorEl.style.color = 'var(--success)';
+    authErrorEl.textContent = 'Te enviamos un correo para restablecer tu contraseña.';
+  }catch(error){
+    authErrorEl.textContent = error.message || 'No se pudo enviar el correo de recuperación.';
+  }
 });
 
-/* ====== DB en la nube (Supabase) ====== */
+/* ====== DB en la nube (API) ====== */
 let cacheClientes = localClients.slice();
 let cacheServicios = [];
 const db = {
@@ -1206,9 +1319,14 @@ const db = {
       cacheClientes = localClients.slice();
       return cacheClientes.slice();
     }
-    const { data, error } = await sb.from('clients').select('*').eq('user_id', currentUser.id).order('nombre', { ascending:true });
-    if(error){ console.error(error); cacheClientes=[]; return cacheClientes; }
-    cacheClientes = data||[]; return cacheClientes.slice();
+    try{
+      const payload = await apiFetch('/clients');
+      cacheClientes = payload?.items || [];
+    }catch(error){
+      console.error(error);
+      cacheClientes = [];
+    }
+    return cacheClientes.slice();
   },
   async saveOne(rec){
     if(!currentUser){
@@ -1220,50 +1338,53 @@ const db = {
       localClients.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||'')); saveLocalClients();
       cacheClientes = localClients.slice(); return payload;
     }
-    const rowNoId = {
-      user_id: currentUser.id,
+    const payload = {
       nombre:rec.nombre, email:rec.email, telefono:rec.telefono, servicio:rec.servicio,
       inicio:rec.inicio, vence:rec.vence, categoria:rec.categoria, notas:rec.notas, pin:rec.pin, ts:rec.ts
     };
-    let data, error; const hasId = rec.id!==undefined && rec.id!==null && `${rec.id}`.trim()!=='';
-    if (!hasId) ({ data, error } = await sb.from('clients').insert(rowNoId).select().single());
-    else {
-      ({ data, error } = await sb.from('clients').update(rowNoId).eq('id', rec.id).select().single());
-      if (error) ({ data, error } = await sb.from('clients').upsert({ ...rowNoId, id: rec.id }, { onConflict: 'id' }).select().single());
+    let saved;
+    const hasId = rec.id!==undefined && rec.id!==null && `${rec.id}`.trim()!=='';
+    if(hasId){
+      const response = await apiFetch(`/clients/${rec.id}`, { method:'PUT', body: payload });
+      saved = response?.item;
+    }else{
+      const response = await apiFetch('/clients', { method:'POST', body: payload });
+      saved = response?.item;
     }
-    if (error) throw error;
-    const i = cacheClientes.findIndex(x=>x.id===data.id);
-    if(i>=0) cacheClientes[i]=data; else cacheClientes.push(data);
-    cacheClientes.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||'')); return data;
+    if(!saved) throw new Error('No se pudo guardar el cliente.');
+    const i = cacheClientes.findIndex(x=>x.id===saved.id);
+    if(i>=0) cacheClientes[i]=saved; else cacheClientes.push(saved);
+    cacheClientes.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||'')); return saved;
   },
   async deleteOne(id){
     if(!currentUser){
       localClients = loadLocalClients().filter(x=>x && x.id!==id); saveLocalClients(); cacheClientes = localClients.slice(); return;
     }
-    const { error } = await sb.from('clients').delete().eq('id', id);
-    if(error) throw error; cacheClientes = cacheClientes.filter(x=>x.id!==id);
+    await apiFetch(`/clients/${id}`, { method:'DELETE' });
+    cacheClientes = cacheClientes.filter(x=>x.id!==id);
   },
   async saveAll(arr){
     if(!currentUser){
       localClients = arr.map(x=>({ ...x })); localClients.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||'')); saveLocalClients(); cacheClientes = localClients.slice(); return;
     }
-    const rows = arr.map(x=>({ ...x, user_id: currentUser.id }));
-    const { error } = await sb.from('clients').upsert(rows, { onConflict:'id' });
-    if(error) throw error; cacheClientes = arr.slice();
+    await apiFetch('/clients/bulk', { method:'PUT', body:{ items: arr } });
+    cacheClientes = arr.slice();
   },
   getServicios(){ return currentUser ? cacheServicios.slice() : localServices.slice(); },
   async fetchServicios(){
     if (!currentUser) return localServices.slice();
-    const { data, error } = await sb.from('services').select('name').eq('user_id', currentUser.id).order('name');
-    if(error){ console.error(error); cacheServicios = []; return []; }
-    cacheServicios = (data||[]).map(x=>x.name); return cacheServicios.slice();
+    try{
+      const payload = await apiFetch('/services');
+      cacheServicios = payload?.items || [];
+    }catch(error){
+      console.error(error);
+      cacheServicios = [];
+    }
+    return cacheServicios.slice();
   },
   async replaceServicios(list){
     if (!currentUser) { localServices = list.slice(); saveLocalServices(); return; }
-    const { data: curr } = await sb.from('services').select('name').eq('user_id', currentUser.id);
-    const has = new Set((curr||[]).map(x=>x.name)); const want = new Set(list);
-    const toDel = [...has].filter(n=>!want.has(n)); if (toDel.length) await sb.from('services').delete().in('name', toDel).eq('user_id', currentUser.id);
-    const toIns = [...want].filter(n=>!has.has(n)).map(n=>({ user_id: currentUser.id, name:n })); if (toIns.length) await sb.from('services').insert(toIns);
+    await apiFetch('/services', { method:'PUT', body:{ items: list } });
     cacheServicios = list.slice();
   }
 };
@@ -1878,7 +1999,7 @@ filterEstado?.addEventListener('change', () => renderTabla());
 })();
 
 /* inicio */
-renderServicios().then(()=>renderTabla());
+ensureAuthInitialized();
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "productos-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node api/server.js"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express server that proxies Supabase auth, client, and service operations using environment variables
- document the backend configuration and new apiBaseUrl setting in the README and provide an .env template
- refactor the dashboard frontend to store sessions locally and call the protected API instead of instantiating Supabase directly

## Testing
- node api/server.js *(fails: requires npm install first)*
- npm install *(fails: registry access blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bcc1c64c832e8ff8eadbda8a4480