### PR TITLE
Add Gemini endpoint with rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@supabase/supabase-js": "^2.45.4",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- add environment configuration for Gemini API access
- install express-rate-limit and create a Gemini-specific limiter
- implement authenticated /api/ai/gemini endpoint that proxies requests to the Gemini API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8c20b8ef0832ea9b4136a5a4b07f9