### PR TITLE
Send verification email after signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,7 +752,8 @@ import {
   GoogleAuthProvider,
   signInWithPopup,
   sendPasswordResetEmail,
-  signOut
+  signOut,
+  sendEmailVerification
 } from 'firebase/auth';
 import {
   collection,
@@ -1490,9 +1491,10 @@ signupForm?.addEventListener('submit', async (event)=>{
   const submitBtn=signupForm.querySelector('button[type="submit"]');
   submitBtn.disabled=true; submitBtn.textContent='Creando cuenta…';
   try{
-    await createUserWithEmailAndPassword(auth, email, pass);
+    const cred=await createUserWithEmailAndPassword(auth, email, pass);
+    await sendEmailVerification(cred.user);
     signupErrorEl.textContent='';
-    toast('¡Cuenta creada!');
+    toast('Revisa tu correo para confirmar tu cuenta');
   }catch(error){
     signupErrorEl.textContent=error.message||'Error inesperado.';
   }finally{


### PR DESCRIPTION
## Summary
- import Firebase Auth's sendEmailVerification helper for the signup flow
- send a verification email after creating a new user and update the confirmation toast message

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9c1e5ba54832eb1c636d1edeed4d2