### PR TITLE
Reinforce email verification check on login flow

### DIFF
--- a/login.html
+++ b/login.html
@@ -197,7 +197,6 @@ import {
   GoogleAuthProvider,
   signInWithPopup,
   sendPasswordResetEmail,
-  sendEmailVerification,   // <-- agrega esta
   signOut                  // <-- y esta
 } from 'firebase/auth';
 
@@ -245,15 +244,12 @@ import {
       btnAuthSubmit.textContent='Procesando…';
       try {
         const cred = await signInWithEmailAndPassword(auth, email, pass);
-        
         await cred.user.reload();
         if (!cred.user.emailVerified) {
-          try { 
-            await sendEmailVerification(cred.user); 
-          } catch (_) {}
-          
-          setError('✉️ Debes verificar tu correo. Te enviamos un email de verificación. Revisa tu bandeja.', 'info');
+          setError('Debes verificar tu correo antes de iniciar sesión');
           await signOut(auth);   // Cierra sesión hasta que confirme
+          btnAuthSubmit.disabled=false;
+          btnAuthSubmit.textContent=originalText;
           return;
         }
         setError('Sesión iniciada. Puedes cerrar esta ventana.', 'success');
@@ -261,6 +257,9 @@ import {
       } catch (error) {
         console.error(error);
         setError(error?.message || 'No se pudo acceder.');
+      } finally {
+        btnAuthSubmit.disabled=false;
+        btnAuthSubmit.textContent=originalText;
       }
 
     });


### PR DESCRIPTION
## Summary
- remove the email verification dispatch from the login page
- block sign-in until the user verifies their email, signing them out if necessary
- ensure the login button is always restored after attempts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c250e328832e850cbe449f8c26bd