### PR TITLE
Send verification email and redirect after signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1494,7 +1494,8 @@ signupForm?.addEventListener('submit', async (event)=>{
     const cred=await createUserWithEmailAndPassword(auth, email, pass);
     await sendEmailVerification(cred.user);
     signupErrorEl.textContent='';
-    toast('Revisa tu correo para confirmar tu cuenta');
+    window.location.href='verify.html';
+    return;
   }catch(error){
     signupErrorEl.textContent=error.message||'Error inesperado.';
   }finally{


### PR DESCRIPTION
## Summary
- send a verification email immediately after creating a new user account
- redirect newly registered users to the email verification page to complete the process

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c5ece594832e9a3390400bdc91dc