### PR TITLE
Add email verification page for pending accounts

### DIFF
--- a/verify.html
+++ b/verify.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verifica tu correo • Zyl0</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <script type="importmap">
+    {
+      "imports": {
+        "firebase/app": "https://www.gstatic.com/firebasejs/10.12.4/firebase-app.js",
+        "firebase/auth": "https://www.gstatic.com/firebasejs/10.12.4/firebase-auth.js",
+        "firebase/firestore": "https://www.gstatic.com/firebasejs/10.12.4/firebase-firestore.js"
+      }
+    }
+  </script>
+  <style>
+    :root{
+      --bg:#030712; --ink:#f8fafc; --ink-soft:#cbd5f5; --muted:#94a3b8;
+      --panel:rgba(15,23,42,.78); --panel-border:rgba(148,163,184,.2);
+      --btn:#f28a2d; --btn-ink:#1c130a; --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.2);
+      --ghost-hover:rgba(255,255,255,.1); --success:#16f2a6; --danger:#f97373; --info:#7dd3fc;
+      font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial;
+    }
+    *{box-sizing:border-box;font-family:inherit;}
+    body{
+      margin:0;
+      min-height:100vh;
+      background:var(--bg);
+      color:var(--ink);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:48px 16px;
+    }
+    body::before{
+      content:"";
+      position:fixed;
+      inset:-40%;
+      background:
+        linear-gradient(rgba(3,7,18,.82),rgba(3,7,18,.82)),
+        url("https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat fixed;
+      pointer-events:none;
+      z-index:-1;
+      filter:blur(14px);
+      transform:scale(1.06);
+    }
+    main{
+      width:min(480px,100%);
+    }
+    .panel{
+      background:var(--panel);
+      border:1px solid var(--panel-border);
+      border-radius:22px;
+      padding:32px;
+      display:grid;
+      gap:20px;
+      box-shadow:0 30px 60px rgba(15,23,42,.58);
+      backdrop-filter:blur(18px);
+    }
+    h1{margin:0;font-size:28px;}
+    p{margin:0;color:var(--muted);line-height:1.5;}
+    .email{
+      font-weight:600;
+      color:var(--ink);
+      word-break:break-word;
+    }
+    .status{
+      min-height:20px;
+      font-size:14px;
+      color:var(--muted);
+    }
+    .status[data-tone="success"]{color:var(--success);}
+    .status[data-tone="danger"]{color:var(--danger);}
+    .status[data-tone="info"]{color:var(--info);}
+    .actions{display:flex;gap:12px;flex-wrap:wrap;}
+    button{
+      border:0;
+      border-radius:14px;
+      padding:10px 18px;
+      cursor:pointer;
+      font-weight:600;
+      transition:background-color .2s ease,transform .2s ease,box-shadow .2s ease;
+    }
+    .primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.32);}
+    .ghost{background:var(--ghost);color:var(--ink);border:1px solid var(--ghost-border);}
+    button:hover:not(:disabled),button:focus-visible:not(:disabled){transform:translateY(-1px);box-shadow:0 14px 24px rgba(5,9,15,.45);}
+    button:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none;}
+    @media(max-width:520px){
+      body{padding:36px 14px;}
+      .panel{padding:28px;}
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <article class="panel" aria-labelledby="verifyTitle">
+      <header>
+        <h1 id="verifyTitle">Verifica tu correo</h1>
+        <p>Confirma tu dirección de correo para acceder al panel de productos.</p>
+      </header>
+      <section>
+        <p>Estamos esperando a que confirmes la dirección:</p>
+        <p class="email" data-user-email>–</p>
+      </section>
+      <p class="status" data-status data-tone="info"></p>
+      <div class="actions">
+        <button type="button" class="primary" id="btnCheck">Ya lo verifiqué</button>
+        <button type="button" class="ghost" id="btnResend">Reenviar correo</button>
+        <button type="button" class="ghost" id="btnSignOut">Cerrar sesión</button>
+      </div>
+    </article>
+  </main>
+
+  <script type="module">
+    import { auth } from './firebaseConfig.js';
+    import {
+      onAuthStateChanged,
+      sendEmailVerification,
+      signOut
+    } from 'firebase/auth';
+
+    const emailEl = document.querySelector('[data-user-email]');
+    const statusEl = document.querySelector('[data-status]');
+    const btnCheck = document.getElementById('btnCheck');
+    const btnResend = document.getElementById('btnResend');
+    const btnSignOut = document.getElementById('btnSignOut');
+    const buttons = [btnCheck, btnResend, btnSignOut];
+
+    function setStatus(message = '', tone = 'info') {
+      if (!statusEl) return;
+      statusEl.textContent = message;
+      statusEl.dataset.tone = tone;
+    }
+
+    function setProcessing(isProcessing) {
+      buttons.forEach(btn => {
+        if (btn) {
+          btn.disabled = isProcessing;
+        }
+      });
+    }
+
+    onAuthStateChanged(auth, user => {
+      if (!user) {
+        window.location.href = 'login.html';
+        return;
+      }
+      emailEl.textContent = user.email || 'Sin correo registrado';
+      if (user.emailVerified) {
+        window.location.href = 'index.html';
+      }
+    });
+
+    btnCheck?.addEventListener('click', async () => {
+      setProcessing(true);
+      setStatus('Revisando verificación…', 'info');
+      try {
+        await auth.currentUser?.reload();
+        const user = auth.currentUser;
+        if (user?.emailVerified) {
+          setStatus('Correo verificado. Redirigiendo…', 'success');
+          window.location.href = 'index.html';
+          return;
+        }
+        setStatus('Todavía no vemos la confirmación. Revisa tu correo o inténtalo de nuevo en unos segundos.', 'danger');
+      } catch (error) {
+        console.error(error);
+        setStatus(error?.message || 'No se pudo comprobar el estado de verificación.', 'danger');
+      } finally {
+        setProcessing(false);
+      }
+    });
+
+    btnResend?.addEventListener('click', async () => {
+      setProcessing(true);
+      setStatus('Enviando un nuevo correo de verificación…', 'info');
+      try {
+        const user = auth.currentUser;
+        if (!user) {
+          throw new Error('No hay una sesión activa.');
+        }
+        await sendEmailVerification(user);
+        setStatus('Te enviamos un nuevo correo de verificación. Revisa tu bandeja de entrada.', 'success');
+      } catch (error) {
+        console.error(error);
+        setStatus(error?.message || 'No se pudo reenviar el correo. Intenta más tarde.', 'danger');
+      } finally {
+        setProcessing(false);
+      }
+    });
+
+    btnSignOut?.addEventListener('click', async () => {
+      setProcessing(true);
+      setStatus('Cerrando sesión…', 'info');
+      try {
+        await signOut(auth);
+        window.location.href = 'login.html';
+      } catch (error) {
+        console.error(error);
+        setStatus(error?.message || 'No se pudo cerrar la sesión.', 'danger');
+        setProcessing(false);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a verification screen for pending accounts with the shared Firebase import map
- show the signed-in email with actions to re-check verification, resend the email, or sign out
- manage async states to disable buttons and surface status messages for each action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c691b658832e8c62c0d37a8066e6