### PR TITLE
Validar verificación de correo antes de cargar dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1419,8 +1419,26 @@ function updateUserState(user){
   subscribeToRemoteServicios(user);
   if(user){ syncLocalServicesToCloudIfEmpty(); }
 }
-onAuthStateChanged(auth, (user)=>{
-  updateUserState(user || null);
+onAuthStateChanged(auth, async (user)=>{
+  if(!user){
+    window.location.href = 'login.html';
+    return;
+  }
+  try{
+    await user.reload();
+  }catch(error){
+    console.error('No se pudo actualizar la sesión del usuario', error);
+    if(authErrorEl){
+      authErrorEl.style.color = 'var(--danger)';
+      authErrorEl.textContent = 'No se pudo verificar tu sesión. Intenta de nuevo.';
+    }
+    return;
+  }
+  if(!user.emailVerified){
+    window.location.href = 'verify.html';
+    return;
+  }
+  updateUserState(user);
 });
 const btnAuthOpen  = document.getElementById('btnAuthOpen');
 const btnAuthSubmit= document.getElementById('btnAuthSubmit');


### PR DESCRIPTION
## Summary
- rework the `onAuthStateChanged` handler to require an authenticated user
- reload the user record, redirect unauthenticated or unverified users, and surface reload errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c8249250832e9d803547abdb306f