### PR TITLE
Enable Firestore persistence in firebaseConfig

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,7 +1,7 @@
 // firebaseConfig.js
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, enableIndexedDbPersistence } from "firebase/firestore";
 
 // Tu configuración real de Firebase
 const firebaseConfig = {
@@ -20,6 +20,14 @@ const app = initializeApp(firebaseConfig);
 // Servicios que sí vas a usar en tu app
 const auth = getAuth(app);
 const db = getFirestore(app);
+
+enableIndexedDbPersistence(db).catch((error) => {
+  if (error.code === "failed-precondition") {
+    console.warn("La persistencia de Firestore solo puede habilitarse en una pestaña a la vez.");
+  } else {
+    console.warn("No se pudo habilitar la persistencia de Firestore:", error);
+  }
+});
 
 // Exporta para usarlos en otros archivos
 export { app, auth, db };


### PR DESCRIPTION
## Summary
- enable Firestore offline persistence by calling `enableIndexedDbPersistence` on the Firestore instance
- log a warning when persistence cannot be enabled due to multiple open tabs or other errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9df90c4f0832eb562305f325db44b