### PR TITLE
Clear cached clients when switching Firebase user

### DIFF
--- a/index.html
+++ b/index.html
@@ -1335,6 +1335,20 @@ function clearCachedClientsForUser(uid){
   if(!key) return;
   try{ localStorage.removeItem(key); }catch{}
 }
+function clearCachedClients(){
+  try{
+    const keysToRemove = [];
+    for(let i=0;i<localStorage.length;i+=1){
+      const key = localStorage.key(i);
+      if(key && key.startsWith(CLIENTS_CACHE_PREFIX)){
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key)=>{
+      try{ localStorage.removeItem(key); }catch{}
+    });
+  }catch{}
+}
 function loadLocalClients(){
   try{
     const raw=localStorage.getItem(LOCAL_CLIENTS_KEY); if(!raw) return [];
@@ -1614,13 +1628,19 @@ function rememberLastClientsUser(uid){
 function handleClientStorageForUser(user){
   const nextUid = user?.uid ? String(user.uid) : null;
   const lastUid = getLastClientsUser();
-  if(lastUid && lastUid !== nextUid){
-    clearCachedClientsForUser(lastUid);
-  }
   if(!nextUid){
+    if(lastUid){
+      clearCachedClientsForUser(lastUid);
+    }
     return;
   }
-  rememberLastClientsUser(nextUid);
+  const isDifferentUser = Boolean(lastUid && lastUid !== nextUid);
+  if(isDifferentUser){
+    clearCachedClients();
+  }
+  if(!lastUid || isDifferentUser){
+    rememberLastClientsUser(nextUid);
+  }
   const cached = loadCachedClientsForUser(nextUid);
   if(cached.length){
     cacheClientes = cached.slice();


### PR DESCRIPTION
## Summary
- add a helper to clear all cached client entries stored in localStorage
- reset cached data and remember the UID when a different Firebase user logs in

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e5b4ebcc832ea0240feb26758cae