### PR TITLE
Evita limpiar cache persistente al cerrar sesión

### DIFF
--- a/index.html
+++ b/index.html
@@ -1629,9 +1629,9 @@ function handleClientStorageForUser(user){
   const nextUid = user?.uid ? String(user.uid) : null;
   const lastUid = getLastClientsUser();
   if(!nextUid){
-    if(lastUid){
-      clearCachedClientsForUser(lastUid);
-    }
+    cacheClientes = [];
+    isClientesBootstrapped = false;
+    renderTabla();
     return;
   }
   const isDifferentUser = Boolean(lastUid && lastUid !== nextUid);


### PR DESCRIPTION
## Summary
- evita eliminar la cache persistente de clientes al cerrar sesión
- restablece únicamente el estado en memoria cuando no hay usuario autenticado

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9ef9ece38832e8e69d176d6889394