### PR TITLE
Reset client state when switching users

### DIFF
--- a/index.html
+++ b/index.html
@@ -1636,7 +1636,9 @@ function handleClientStorageForUser(user){
   }
   const isDifferentUser = Boolean(lastUid && lastUid !== nextUid);
   if(isDifferentUser){
-    clearCachedClients();
+    cacheClientes = [];
+    isClientesBootstrapped = false;
+    renderTabla();
   }
   if(!lastUid || isDifferentUser){
     rememberLastClientsUser(nextUid);


### PR DESCRIPTION
## Summary
- reset the in-memory client cache when a different user signs in
- preserve cached data for other users while loading the new user's entries

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9f02a50e4832eadc89871b49d9e67