### PR TITLE
Adjust client cache reset for user switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -1614,6 +1614,14 @@ let cacheClientes = localClients.slice();
 let cacheServicios = localServices.slice();
 let isClientesBootstrapped = true;
 
+function resetClientMemoryState({ render = true } = {}){
+  cacheClientes = [];
+  isClientesBootstrapped = false;
+  if(render){
+    renderTabla();
+  }
+}
+
 function clearStoredClients(){
   localClients = [];
   try{ localStorage.removeItem(LOCAL_CLIENTS_KEY); }catch{}
@@ -1629,16 +1637,12 @@ function handleClientStorageForUser(user){
   const nextUid = user?.uid ? String(user.uid) : null;
   const lastUid = getLastClientsUser();
   if(!nextUid){
-    cacheClientes = [];
-    isClientesBootstrapped = false;
-    renderTabla();
+    resetClientMemoryState();
     return;
   }
   const isDifferentUser = Boolean(lastUid && lastUid !== nextUid);
   if(isDifferentUser){
-    cacheClientes = [];
-    isClientesBootstrapped = false;
-    renderTabla();
+    resetClientMemoryState();
   }
   if(!lastUid || isDifferentUser){
     rememberLastClientsUser(nextUid);


### PR DESCRIPTION
## Summary
- add a helper to reset the in-memory client cache without touching persisted storage
- refresh handleClientStorageForUser to rely on the helper and reload cached data for the active user

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f0fcc47c832ea58988d9bd0c4c23