### PR TITLE
Implement user-scoped client cache handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1335,20 +1335,6 @@ function clearCachedClientsForUser(uid){
   if(!key) return;
   try{ localStorage.removeItem(key); }catch{}
 }
-function clearCachedClients(){
-  try{
-    const keysToRemove = [];
-    for(let i=0;i<localStorage.length;i+=1){
-      const key = localStorage.key(i);
-      if(key && key.startsWith(CLIENTS_CACHE_PREFIX)){
-        keysToRemove.push(key);
-      }
-    }
-    keysToRemove.forEach((key)=>{
-      try{ localStorage.removeItem(key); }catch{}
-    });
-  }catch{}
-}
 function loadLocalClients(){
   try{
     const raw=localStorage.getItem(LOCAL_CLIENTS_KEY); if(!raw) return [];
@@ -1617,6 +1603,10 @@ let isClientesBootstrapped = true;
 function resetClientMemoryState({ render = true } = {}){
   cacheClientes = [];
   isClientesBootstrapped = false;
+  if(unsubscribeClientes){
+    try{ unsubscribeClientes(); }catch{}
+    unsubscribeClientes = null;
+  }
   if(render){
     renderTabla();
   }


### PR DESCRIPTION
## Summary
- prevent accidental clearing of all user caches by removing the global clear helper
- ensure the in-memory client cache reset unsubscribes listeners without touching persistent storage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f3bfe64c832ebfd7dd521cb59c5d