### PR TITLE
Ajusta orden de render y persistencia de clientes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1405,11 +1405,11 @@ function subscribeToRemoteClientes(user){
       return { id: docSnap.id, ...data };
     });
     cacheClientes.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||''));
+    isClientesBootstrapped = true;
+    renderTabla();
     if(currentUser?.uid){
       saveCachedClientsForUser(currentUser.uid, cacheClientes);
     }
-    isClientesBootstrapped = true;
-    renderTabla();
   }, (error)=>{
     console.error('Error al escuchar clientes', error);
     toast('No se pudo cargar tus clientes en tiempo real.');


### PR DESCRIPTION
## Summary
- Invoca renderTabla inmediatamente después de ordenar cacheClientes en el snapshot
- Persiste la caché de clientes únicamente tras completar el renderizado exitosamente

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da05d08b8c832e816c27d810819b5e