### PR TITLE
Evita parpadeo al restaurar caché de clientes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1630,21 +1630,26 @@ function handleClientStorageForUser(user){
     resetClientMemoryState();
     return;
   }
+  const cached = loadCachedClientsForUser(nextUid);
+  const hasCached = cached.length > 0;
   const isDifferentUser = Boolean(lastUid && lastUid !== nextUid);
-  if(isDifferentUser){
-    resetClientMemoryState();
+  const shouldResetState = !lastUid || isDifferentUser;
+  if(shouldResetState){
+    resetClientMemoryState({ render: !hasCached });
   }
   if(!lastUid || isDifferentUser){
     rememberLastClientsUser(nextUid);
   }
-  const cached = loadCachedClientsForUser(nextUid);
-  if(cached.length){
+  if(hasCached){
     cacheClientes = cached.slice();
     isClientesBootstrapped = true;
     renderTabla();
   }else{
     cacheClientes = [];
     isClientesBootstrapped = false;
+    if(!shouldResetState){
+      renderTabla();
+    }
   }
 }
 
@@ -1764,7 +1769,7 @@ async function renderServicios(sel){
   handleEmailSuggestionSelection();
 }
 async function renderTabla(){
-  if(currentUser && !isClientesBootstrapped){
+  if(currentUser && !isClientesBootstrapped && cacheClientes.length === 0){
     tbody.innerHTML = '<tr class="table-loading"><td colspan="8" data-label="">Cargando clientes…</td></tr>';
     return;
   }


### PR DESCRIPTION
## Summary
- Evita renderizar el estado de carga al cambiar de usuario cuando existe caché local disponible
- Sincroniza la bandera de bootstrapping y el renderizado para que la tabla muestre datos cacheados antes del onSnapshot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0650aee0832e8669bbde90ea3114