### PR TITLE
Await renderTabla before caching remote clients

### DIFF
--- a/index.html
+++ b/index.html
@@ -1399,14 +1399,14 @@ function subscribeToRemoteClientes(user){
     renderTabla();
   }
   const colRef = clientesCollection();
-  unsubscribeClientes = onSnapshot(colRef, (snapshot)=>{
+  unsubscribeClientes = onSnapshot(colRef, async (snapshot)=>{
     cacheClientes = snapshot.docs.map(docSnap=>{
       const data = normalizeRemoteRecord(docSnap.data());
       return { id: docSnap.id, ...data };
     });
     cacheClientes.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||''));
     isClientesBootstrapped = true;
-    renderTabla();
+    await renderTabla();
     if(currentUser?.uid){
       saveCachedClientsForUser(currentUser.uid, cacheClientes);
     }


### PR DESCRIPTION
## Summary
- make the clientes onSnapshot listener async
- await renderTabla so UI rendering completes before caching data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0cc5de20832ebcfd1259a9b5dfa5