### PR TITLE
Ensure client snapshot rendering precedes cache writes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1354,6 +1354,9 @@ function saveLocalClients(){
 let currentUser = null;
 let unsubscribeClientes = null;
 let unsubscribeServicios = null;
+let snapshotRenderQueue = Promise.resolve();
+let latestSnapshotVersion = 0;
+let activeSnapshotSession = 0;
 
 function authUpdateUI(){
   const badge = document.getElementById('userInfo');
@@ -1386,10 +1389,13 @@ function serviciosDoc(){
 }
 function subscribeToRemoteClientes(user){
   if(unsubscribeClientes){ unsubscribeClientes(); unsubscribeClientes = null; }
+  const sessionId = ++activeSnapshotSession;
+  latestSnapshotVersion = 0;
+  snapshotRenderQueue = Promise.resolve();
   if(!user){
     cacheClientes = localClients.slice();
     isClientesBootstrapped = true;
-    renderTabla();
+    renderTabla(cacheClientes);
     return;
   }
   const hasPreloadedData = Array.isArray(cacheClientes) && cacheClientes.length>0 && isClientesBootstrapped;
@@ -1399,17 +1405,45 @@ function subscribeToRemoteClientes(user){
     renderTabla();
   }
   const colRef = clientesCollection();
-  unsubscribeClientes = onSnapshot(colRef, async (snapshot)=>{
-    cacheClientes = snapshot.docs.map(docSnap=>{
+  if(!colRef) return;
+  unsubscribeClientes = onSnapshot(colRef, (snapshot)=>{
+    const fresh = snapshot.docs.map(docSnap=>{
       const data = normalizeRemoteRecord(docSnap.data());
       return { id: docSnap.id, ...data };
     });
-    cacheClientes.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||''));
+    fresh.sort((a,b)=> (a.nombre||'').localeCompare(b.nombre||''));
+    cacheClientes = fresh.slice();
     isClientesBootstrapped = true;
-    await renderTabla();
-    if(currentUser?.uid){
-      saveCachedClientsForUser(currentUser.uid, cacheClientes);
+    if(sessionId !== activeSnapshotSession){
+      return;
     }
+    const version = ++latestSnapshotVersion;
+    snapshotRenderQueue = snapshotRenderQueue.catch(()=>{});
+    snapshotRenderQueue = snapshotRenderQueue.then(async ()=>{
+      if(sessionId !== activeSnapshotSession){
+        return;
+      }
+      if(version < latestSnapshotVersion){
+        return;
+      }
+      try{
+        await renderTabla(fresh);
+      }catch(error){
+        console.error('Error al renderizar clientes tras snapshot', error);
+        return;
+      }
+      if(sessionId !== activeSnapshotSession || version !== latestSnapshotVersion){
+        return;
+      }
+      if(currentUser?.uid){
+        try{
+          // En snapshot, esperar render y luego guardar caché (render → save).
+          saveCachedClientsForUser(currentUser.uid, fresh);
+        }catch(error){
+          console.warn('No se pudo guardar la caché de clientes', error);
+        }
+      }
+    });
   }, (error)=>{
     console.error('Error al escuchar clientes', error);
     toast('No se pudo cargar tus clientes en tiempo real.');
@@ -1450,11 +1484,9 @@ async function syncLocalServicesToCloudIfEmpty(){
     console.error('No se pudo sincronizar servicios locales', error);
   }
 }
-function updateUserState(user){
+async function updateUserState(user){
   currentUser = user;
-  if(user){
-    handleClientStorageForUser(user);
-  }
+  await handleClientStorageForUser(user);
   if(user){
     hideLanding();
   }else{
@@ -1466,7 +1498,9 @@ function updateUserState(user){
   if(user){ syncLocalServicesToCloudIfEmpty(); }
 }
 onAuthStateChanged(auth, (user)=>{
-  updateUserState(user || null);
+  updateUserState(user || null).catch(err=>{
+    console.error('No se pudo actualizar el estado del usuario', err);
+  });
 });
 const btnAuthOpen  = document.getElementById('btnAuthOpen');
 const btnAuthSubmit= document.getElementById('btnAuthSubmit');
@@ -1623,7 +1657,7 @@ function rememberLastClientsUser(uid){
   if(!uid) return;
   try{ localStorage.setItem(CLIENTS_LAST_USER_KEY, uid); }catch{}
 }
-function handleClientStorageForUser(user){
+async function handleClientStorageForUser(user){
   const nextUid = user?.uid ? String(user.uid) : null;
   const lastUid = getLastClientsUser();
   if(!nextUid){
@@ -1643,12 +1677,13 @@ function handleClientStorageForUser(user){
   if(hasCached){
     cacheClientes = cached.slice();
     isClientesBootstrapped = true;
-    renderTabla();
+    // Ruta “caché primero”: no repintar la tabla en blanco cuando hay datos locales.
+    await renderTabla(cacheClientes);
   }else{
     cacheClientes = [];
     isClientesBootstrapped = false;
     if(!shouldResetState){
-      renderTabla();
+      await renderTabla();
     }
   }
 }
@@ -1768,13 +1803,26 @@ async function renderServicios(sel){
   rebuildEmailSuggestions();
   handleEmailSuggestionSelection();
 }
-async function renderTabla(){
-  if(currentUser && !isClientesBootstrapped && cacheClientes.length === 0){
+function waitForNextFrame(){
+  return new Promise(resolve=>{
+    if(typeof requestAnimationFrame === 'function'){
+      requestAnimationFrame(()=>resolve());
+    }else{
+      setTimeout(resolve,0);
+    }
+  });
+}
+
+async function renderTabla(source){
+  const hasExternalSource = Array.isArray(source);
+  if(!hasExternalSource && currentUser && !isClientesBootstrapped && cacheClientes.length === 0){
     tbody.innerHTML = '<tr class="table-loading"><td colspan="8" data-label="">Cargando clientes…</td></tr>';
+    await waitForNextFrame();
     return;
   }
-  const arr = await db.fetchAll();
-  const items=arr.filter(x=>coincide(x,q?.value)&&pasaEstado(x,filterEstado?.value))
+  const arr = hasExternalSource ? source : await db.fetchAll();
+  const list = Array.isArray(arr) ? arr : [];
+  const items=list.filter(x=>coincide(x,q?.value)&&pasaEstado(x,filterEstado?.value))
                  .sort((a,b)=> (diasRestantes(a.vence)??1e9) - (diasRestantes(b.vence)??1e9));
   tbody.innerHTML=items.map(x=>{
     const d=diasRestantes(x.vence); const est=estadoDe(x.vence);
@@ -1801,6 +1849,7 @@ async function renderTabla(){
       </td>
     </tr>`;
   }).join('');
+  await waitForNextFrame();
 }
 function coincide(x,qq){
   qq=(qq||'').trim().toLowerCase(); if(!qq) return true;


### PR DESCRIPTION
## Summary
- ensure Firestore snapshot handling waits for table rendering before persisting the user cache, using a serialized queue
- make renderTabla awaitable with a paint wait helper and respect the cache-first path without blanking the table when cached data exists
- guard against stale renders across auth changes while keeping cache persistence untouched on logout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da103225ec832e8f844ec938806b02