### PR TITLE
Handle Firestore persistence conflicts

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,7 +1,7 @@
 // firebaseConfig.js
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, enableIndexedDbPersistence } from "firebase/firestore";
 
 // Tu configuración real de Firebase
 const firebaseConfig = {
@@ -21,5 +21,21 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 
+let persistenceEnabled = true;
+let persistenceError = null;
+
+const persistenceReady = enableIndexedDbPersistence(db).catch(error => {
+  persistenceEnabled = false;
+  persistenceError = error;
+  if (error?.code === "failed-precondition") {
+    console.info("Firestore persistence disabled: another tab already has persistence enabled.");
+  } else if (error?.code === "unimplemented") {
+    console.info("Firestore persistence disabled: the current browser doesn't support IndexedDB persistence.");
+  } else {
+    console.error("Unexpected error enabling Firestore persistence", error);
+  }
+  throw error;
+});
+
 // Exporta para usarlos en otros archivos
-export { app, auth, db };
+export { app, auth, db, persistenceReady, persistenceEnabled, persistenceError };

--- a/index.html
+++ b/index.html
@@ -744,7 +744,7 @@
 </div>
 
 <script type="module">
-import { auth, db as firestore } from './firebaseConfig.js';
+import { auth, db as firestore, persistenceReady } from './firebaseConfig.js';
 import {
   onAuthStateChanged,
   createUserWithEmailAndPassword,
@@ -766,6 +766,19 @@ import {
   setDoc,
   getDoc
 } from 'firebase/firestore';
+
+const persistenceReadyForInit = persistenceReady.catch(error => {
+  if (error?.code === 'failed-precondition') {
+    console.info('IndexedDB persistence unavailable: another tab already has offline data. Falling back to memory cache.');
+    toast('Otra pestaña ya tiene los datos sin conexión activos. Esta usará conexión en línea.');
+  } else if (error?.code === 'unimplemented') {
+    console.info('IndexedDB persistence unavailable: browser does not support it.');
+    toast('Tu navegador no soporta el modo sin conexión de Firestore.');
+  } else if (error) {
+    console.error('No se pudo activar la persistencia de Firestore', error);
+    toast('No se pudo activar el modo sin conexión.');
+  }
+});
 
 /* ===== helpers y refs ===== */
 const $=s=>document.querySelector(s);
@@ -1498,9 +1511,11 @@ async function updateUserState(user){
   if(user){ syncLocalServicesToCloudIfEmpty(); }
 }
 onAuthStateChanged(auth, (user)=>{
-  updateUserState(user || null).catch(err=>{
-    console.error('No se pudo actualizar el estado del usuario', err);
-  });
+  persistenceReadyForInit
+    .then(()=>updateUserState(user || null))
+    .catch(err=>{
+      console.error('No se pudo actualizar el estado del usuario', err);
+    });
 });
 const btnAuthOpen  = document.getElementById('btnAuthOpen');
 const btnAuthSubmit= document.getElementById('btnAuthSubmit');


### PR DESCRIPTION
## Summary
- enable IndexedDB persistence for Firestore and expose the status promise
- surface persistence conflicts or unsupported browsers to the UI
- wait for the persistence promise before wiring realtime subscriptions after auth changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da151507f8832ea2bd062fe6b5bef6