### PR TITLE
Update Firestore persistence messaging

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -28,7 +28,7 @@ const persistenceReady = enableIndexedDbPersistence(db).catch(error => {
   persistenceEnabled = false;
   persistenceError = error;
   if (error?.code === "failed-precondition") {
-    console.info("Firestore persistence disabled: another tab already has persistence enabled.");
+    console.warn("La persistencia de Firestore solo puede habilitarse en una pestaña a la vez");
   } else if (error?.code === "unimplemented") {
     console.info("Firestore persistence disabled: the current browser doesn't support IndexedDB persistence.");
   } else {

--- a/index.html
+++ b/index.html
@@ -769,8 +769,8 @@ import {
 
 const persistenceReadyForInit = persistenceReady.catch(error => {
   if (error?.code === 'failed-precondition') {
-    console.info('IndexedDB persistence unavailable: another tab already has offline data. Falling back to memory cache.');
-    toast('Otra pestaña ya tiene los datos sin conexión activos. Esta usará conexión en línea.');
+    console.warn('La persistencia de Firestore solo puede habilitarse en una pestaña a la vez');
+    toast('La persistencia de Firestore solo puede habilitarse en una pestaña a la vez');
   } else if (error?.code === 'unimplemented') {
     console.info('IndexedDB persistence unavailable: browser does not support it.');
     toast('Tu navegador no soporta el modo sin conexión de Firestore.');


### PR DESCRIPTION
## Summary
- replace the Firestore persistence warning in firebaseConfig.js with the requested message
- align the console and toast messaging in index.html when persistence cannot be enabled due to another tab

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da19c76408832e943dfcbb16d89594