### PR TITLE
Remove dark theme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,159 +105,7 @@
       filter:none;
       transform:none;
     }
-    @media(prefers-color-scheme: dark){
-      :root:not([data-theme]){
-        color-scheme:dark;
-        --bg:#000000; --ink:#f8fafc; --ink-soft:#d2d9e6; --muted:#9aa7bb;
-        --field:rgba(14,18,26,.85); --field-focus:rgba(20,26,36,.92); --border:rgba(255,255,255,.12);
-        --pill-bg:rgba(249,115,22,.18); --pill-ink:#ffd7a3;
-        --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.18);
-        --ghost-hover-bg:rgba(255,255,255,.12); --ghost-active-bg:rgba(255,255,255,.18);
-        --ghost-hover-border:rgba(255,255,255,.26); --ghost-active-border:rgba(255,255,255,.32);
-        --ok:#4ade80; --warn:#fbbf24; --bad:#fb7185; --link:#7dd3fc;
-        --success:#16f2a6; --danger:#f97373; --shadow:0 30px 60px rgba(3,6,10,.55);
-        --toolbar-bg:rgba(6,9,15,.82);
-        --input-bg:rgba(255,255,255,.05);
-        --input-border:rgba(255,255,255,.14);
-        --input-focus-border:rgba(125,211,252,.6);
-        --input-focus-shadow:rgba(125,211,252,.2);
-        --input-inner-shadow:inset 0 1px 0 rgba(255,255,255,.06);
-        --ghost-inner-shadow:inset 0 1px 0 rgba(255,255,255,.05);
-        --surface-inner-shadow:inset 0 1px 0 rgba(255,255,255,.04);
-        --card-bg:rgba(255,255,255,.06);
-        --table-card-bg:rgba(255,255,255,.05);
-        --table-border:rgba(255,255,255,.08);
-        --table-row-alt-bg:rgba(255,255,255,.03);
-        --table-row-hover-bg:rgba(125,211,252,.12);
-        --table-row-hover-shadow:inset 0 0 0 999px rgba(5,9,15,.12);
-        --menu-bg:rgba(10,14,22,.96);
-        --menu-hover-bg:rgba(255,255,255,.08);
-        --modal-bg:rgba(10,14,22,.92);
-        --backdrop-bg:rgba(3,6,11,.78);
-        --chat-log-bg:rgba(255,255,255,.05);
-        --ai-bubble-bg:rgba(15,20,28,.92);
-        --ai-bubble-border:rgba(255,255,255,.12);
-        --eye-bg:rgba(255,255,255,.08);
-        --eye-border:rgba(255,255,255,.18);
-        --addserv-bg:rgba(125,211,252,.18);
-        --addserv-border:rgba(125,211,252,.55);
-        --addserv-hover-bg:rgba(125,211,252,.26);
-        --addserv-hover-border:rgba(125,211,252,.65);
-        --addserv-active-bg:rgba(125,211,252,.32);
-        --addserv-active-border:rgba(125,211,252,.75);
-        --addserv-ink:#e0f2fe;
-        --tag-border:rgba(255,255,255,.2);
-        --tag-bg:rgba(255,255,255,.05);
-      }
-      :root:not([data-theme]) body::before{
-        background:
-          linear-gradient(rgba(0,0,0,.78),rgba(0,0,0,.78)),
-          url("https://images.unsplash.com/photo-1524230572899-a752b3835840?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat fixed;
-        filter:blur(12px);
-        transform:scale(1.06);
-      }
-    }
-    html[data-theme='light']{
-      color-scheme:light;
-      --bg:#f8fafc; --ink:#0f172a; --ink-soft:#1e293b; --muted:#475569;
-      --field:#ffffff; --field-focus:#f1f5f9; --border:rgba(148,163,184,.35);
-      --pill-bg:rgba(59,130,246,.14); --pill-ink:#1d4ed8;
-      --ghost:rgba(226,232,240,.8); --ghost-border:rgba(148,163,184,.6);
-      --ghost-hover-bg:rgba(148,163,184,.28); --ghost-active-bg:rgba(148,163,184,.36);
-      --ghost-hover-border:rgba(100,116,139,.6); --ghost-active-border:rgba(71,85,105,.6);
-      --link:#2563eb;
-      --shadow:0 18px 40px rgba(15,23,42,.12);
-      --toolbar-bg:rgba(255,255,255,.86);
-      --input-bg:#ffffff;
-      --input-border:rgba(148,163,184,.55);
-      --input-focus-border:rgba(37,99,235,.5);
-      --input-focus-shadow:rgba(37,99,235,.18);
-      --input-inner-shadow:inset 0 1px 0 rgba(148,163,184,.1);
-      --ghost-inner-shadow:inset 0 1px 0 rgba(255,255,255,.6);
-      --surface-inner-shadow:inset 0 1px 0 rgba(148,163,184,.08);
-      --card-bg:#ffffff;
-      --table-card-bg:#ffffff;
-      --table-border:rgba(226,232,240,.9);
-      --table-row-alt-bg:rgba(226,232,240,.6);
-      --table-row-hover-bg:rgba(59,130,246,.12);
-      --table-row-hover-shadow:inset 0 0 0 999px rgba(15,23,42,.08);
-      --menu-bg:#ffffff;
-      --menu-hover-bg:rgba(226,232,240,.9);
-      --modal-bg:#ffffff;
-      --backdrop-bg:rgba(15,23,42,.35);
-      --chat-log-bg:#f8fafc;
-      --ai-bubble-bg:#e2e8f0;
-      --ai-bubble-border:rgba(148,163,184,.4);
-      --eye-bg:#e2e8f0;
-      --eye-border:rgba(148,163,184,.7);
-      --addserv-bg:rgba(191,219,254,.85);
-      --addserv-border:rgba(59,130,246,.45);
-      --addserv-hover-bg:rgba(191,219,254,.95);
-      --addserv-hover-border:rgba(59,130,246,.55);
-      --addserv-active-bg:rgba(191,219,254,1);
-      --addserv-active-border:rgba(37,99,235,.65);
-      --addserv-ink:#1d4ed8;
-      --tag-border:rgba(148,163,184,.6);
-      --tag-bg:#e2e8f0;
-    }
-    html[data-theme='light'] body::before{
-      background:
-        radial-gradient(circle at 20% 20%,rgba(59,130,246,.15),rgba(148,163,184,0) 45%),
-        radial-gradient(circle at 80% 10%,rgba(16,185,129,.12),rgba(148,163,184,0) 52%),
-        radial-gradient(circle at 30% 80%,rgba(249,115,22,.12),rgba(148,163,184,0) 55%);
-      filter:none;
-      transform:none;
-    }
-    html[data-theme='dark']{
-      color-scheme:dark;
-      --bg:#000000; --ink:#f8fafc; --ink-soft:#d2d9e6; --muted:#9aa7bb;
-      --field:rgba(14,18,26,.85); --field-focus:rgba(20,26,36,.92); --border:rgba(255,255,255,.12);
-      --pill-bg:rgba(249,115,22,.18); --pill-ink:#ffd7a3;
-      --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.18);
-      --ghost-hover-bg:rgba(255,255,255,.12); --ghost-active-bg:rgba(255,255,255,.18);
-      --ghost-hover-border:rgba(255,255,255,.26); --ghost-active-border:rgba(255,255,255,.32);
-      --link:#7dd3fc;
-      --shadow:0 30px 60px rgba(3,6,10,.55);
-      --toolbar-bg:rgba(6,9,15,.82);
-      --input-bg:rgba(255,255,255,.05);
-      --input-border:rgba(255,255,255,.14);
-      --input-focus-border:rgba(125,211,252,.6);
-      --input-focus-shadow:rgba(125,211,252,.2);
-      --input-inner-shadow:inset 0 1px 0 rgba(255,255,255,.06);
-      --ghost-inner-shadow:inset 0 1px 0 rgba(255,255,255,.05);
-      --surface-inner-shadow:inset 0 1px 0 rgba(255,255,255,.04);
-      --card-bg:rgba(255,255,255,.06);
-      --table-card-bg:rgba(255,255,255,.05);
-      --table-border:rgba(255,255,255,.08);
-      --table-row-alt-bg:rgba(255,255,255,.03);
-      --table-row-hover-bg:rgba(125,211,252,.12);
-      --table-row-hover-shadow:inset 0 0 0 999px rgba(5,9,15,.12);
-      --menu-bg:rgba(10,14,22,.96);
-      --menu-hover-bg:rgba(255,255,255,.08);
-      --modal-bg:rgba(10,14,22,.92);
-      --backdrop-bg:rgba(3,6,11,.78);
-      --chat-log-bg:rgba(255,255,255,.05);
-      --ai-bubble-bg:rgba(15,20,28,.92);
-      --ai-bubble-border:rgba(255,255,255,.12);
-      --eye-bg:rgba(255,255,255,.08);
-      --eye-border:rgba(255,255,255,.18);
-      --addserv-bg:rgba(125,211,252,.18);
-      --addserv-border:rgba(125,211,252,.55);
-      --addserv-hover-bg:rgba(125,211,252,.26);
-      --addserv-hover-border:rgba(125,211,252,.65);
-      --addserv-active-bg:rgba(125,211,252,.32);
-      --addserv-active-border:rgba(125,211,252,.75);
-      --addserv-ink:#e0f2fe;
-      --tag-border:rgba(255,255,255,.2);
-      --tag-bg:rgba(255,255,255,.05);
-    }
-    html[data-theme='dark'] body::before{
-      background:
-        linear-gradient(rgba(0,0,0,.78),rgba(0,0,0,.78)),
-        url("https://images.unsplash.com/photo-1524230572899-a752b3835840?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat fixed;
-      filter:blur(12px);
-      transform:scale(1.06);
-    }
+    
     a{color:inherit}
 
     body.sidebar-expanded{padding-left:260px}
@@ -646,11 +494,6 @@
               <option value="vencida">Vencidas</option>
             </select>
           </li>
-          <li>
-            <div class="theme-switcher" role="status" aria-live="polite">
-              <span class="label">Tema detectado: <span id="themeLabel">Oscuro</span></span>
-            </div>
-          </li>
           <li class="auth-controls">
             <button class="btn ghost label" id="btnAuthOpen">Acceder</button>
             <button class="btn ghost label" id="btnLogout" style="display:none">Cerrar sesión</button>
@@ -950,9 +793,6 @@ landingLoginBtn?.addEventListener('click',event=>{
 landingBackButtons.forEach(btn=>{
   btn.addEventListener('click',()=>setLandingView('home'));
 });
-
-const themeLabel=document.getElementById('themeLabel');
-const themeMedia=window.matchMedia? window.matchMedia('(prefers-color-scheme: dark)') : null;
 
 let editId=null;
 const views={form:vistaFormulario,clientes:vistaClientes};
@@ -1256,27 +1096,6 @@ setupScrollFade();
 function toast(t){ msg.textContent=t; setTimeout(()=>msg.textContent='',2200); }
 function esc(s){return (s||'').replace(/[&<>"']/g,m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;' }[m]))}
 function fmt(iso){return iso? new Date(iso+'T00:00:00').toLocaleDateString(): '-'}
-
-/* ===== Tema ===== */
-function resolveSystemTheme(){
-  return themeMedia && themeMedia.matches ? 'dark' : 'light';
-}
-function updateThemeControls(mode){
-  if(themeLabel){ themeLabel.textContent = mode==='light' ? 'Claro' : 'Oscuro'; }
-}
-function applySystemTheme(){
-  const active = resolveSystemTheme();
-  updateThemeControls(active);
-  return active;
-}
-applySystemTheme();
-if(themeMedia){
-  const handleSystemThemeChange = ()=>{
-    applySystemTheme();
-  };
-  if(themeMedia.addEventListener){ themeMedia.addEventListener('change', handleSystemThemeChange); }
-  else if(themeMedia.addListener){ themeMedia.addListener(handleSystemThemeChange); }
-}
 
 /* ===== sidebar responsive ===== */
 const sidebarMobileQuery=window.matchMedia? window.matchMedia('(max-width: 768px)') : { matches:false };


### PR DESCRIPTION
## Summary
- remove dark-mode CSS rules and leave the light theme variables as the defaults
- delete the sidebar theme indicator that depended on the dark-mode logic
- strip out the JavaScript that detected system theme changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc75817a00832e9276613c81238669