### PR TITLE
Replace glassmorphism blurs with solid surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
       --ghost-hover-bg:rgba(148,163,184,.28); --ghost-active-bg:rgba(148,163,184,.36);
       --ghost-hover-border:rgba(100,116,139,.6); --ghost-active-border:rgba(71,85,105,.6);
       --ok:#4ade80; --warn:#fbbf24; --bad:#fb7185; --link:#2563eb;
-      --success:#16f2a6; --danger:#f97373; --shadow:0 18px 40px rgba(15,23,42,.12);
-      --toolbar-bg:rgba(255,255,255,.86);
+      --success:#16f2a6; --danger:#f97373; --shadow:0 10px 24px rgba(15,23,42,.14);
+      --toolbar-bg:rgba(255,255,255,.92);
       --input-bg:#ffffff;
       --input-border:rgba(148,163,184,.55);
       --input-focus-border:rgba(37,99,235,.5);
@@ -66,13 +66,13 @@
     .landing{min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:40px;padding:48px 16px;text-align:center}
     .landing[hidden]{display:none}
     .landing-hero{max-width:640px;display:grid;gap:18px;justify-items:center}
-    .landing-logo{width:84px;height:84px;border-radius:24px;background:linear-gradient(135deg,var(--btn),#facc15);display:flex;align-items:center;justify-content:center;font-size:42px;box-shadow:0 30px 60px rgba(0,0,0,.5)}
+    .landing-logo{width:84px;height:84px;border-radius:24px;background:linear-gradient(135deg,var(--btn),#facc15);display:flex;align-items:center;justify-content:center;font-size:42px;box-shadow:0 12px 28px rgba(15,23,42,.18)}
     .landing-pill{padding:6px 16px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase;margin:0}
     .landing-title{margin:0;font-size:clamp(34px,8vw,68px);font-weight:800;color:var(--ink);text-shadow:0 14px 32px rgba(0,0,0,.45)}
     .landing-subtitle{margin:0;color:var(--ink-soft);font-size:16px;line-height:1.6}
     .landing-actions{display:flex;gap:14px;flex-wrap:wrap;justify-content:center}
     .landing-panels{width:min(520px,92vw);display:grid;gap:20px}
-    .landing-panel{background:var(--card-bg);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);backdrop-filter:blur(22px);text-align:left;display:grid;gap:18px}
+    .landing-panel{background:linear-gradient(180deg,#ffffff 0%,#f2f5fa 100%);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);text-align:left;display:grid;gap:18px}
     .landing-panel[hidden]{display:none}
     .landing-panel h2{margin:0;font-size:24px;font-weight:700;color:var(--ink)}
     .landing-panel p{margin:0;color:var(--muted);line-height:1.5}
@@ -97,36 +97,34 @@
       position:fixed;
       inset:-40%;
       background:
-        radial-gradient(circle at 20% 20%,rgba(59,130,246,.15),rgba(148,163,184,0) 45%),
-        radial-gradient(circle at 80% 10%,rgba(16,185,129,.12),rgba(148,163,184,0) 52%),
-        radial-gradient(circle at 30% 80%,rgba(249,115,22,.12),rgba(148,163,184,0) 55%);
+        radial-gradient(circle at 20% 20%,rgba(59,130,246,.12),rgba(148,163,184,0) 45%),
+        radial-gradient(circle at 80% 10%,rgba(16,185,129,.1),rgba(148,163,184,0) 52%),
+        radial-gradient(circle at 30% 80%,rgba(249,115,22,.1),rgba(148,163,184,0) 55%);
       pointer-events:none;
       z-index:-1;
-      filter:none;
-      transform:none;
     }
     
     a{color:inherit}
 
     body.sidebar-expanded{padding-left:260px}
     /* ===== Sidebar y lanzador flotante ===== */
-    .sidebar-launcher{position:fixed;top:20px;left:20px;width:54px;height:54px;border-radius:999px;border:1px solid var(--ghost-border);background:var(--card-bg);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;z-index:60;box-shadow:0 18px 36px rgba(0,0,0,.45);backdrop-filter:blur(18px);transition:left .3s ease,transform .2s ease,box-shadow .2s ease,background-color .2s ease,border-color .2s ease}
-    .sidebar-launcher:hover,.sidebar-launcher:focus-visible{transform:translateY(-1px);box-shadow:0 24px 40px rgba(0,0,0,.5);background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
-    .sidebar-launcher:active{transform:translateY(0);box-shadow:0 14px 28px rgba(0,0,0,.55)}
+    .sidebar-launcher{position:fixed;top:20px;left:20px;width:54px;height:54px;border-radius:999px;border:1px solid var(--ghost-border);background:linear-gradient(150deg,#ffffff 0%,#edf2ff 100%);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;z-index:60;box-shadow:0 8px 20px rgba(15,23,42,.18);transition:left .3s ease,transform .2s ease,box-shadow .2s ease,background-color .2s ease,border-color .2s ease}
+    .sidebar-launcher:hover,.sidebar-launcher:focus-visible{transform:translateY(-1px);box-shadow:0 12px 24px rgba(15,23,42,.22);background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
+    .sidebar-launcher:active{transform:translateY(0);box-shadow:0 6px 14px rgba(15,23,42,.2)}
     .sidebar-launcher:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:3px}
-    .sidebar-launcher.is-open{background:var(--btn);color:var(--btn-ink);border-color:var(--ghost-hover-border);box-shadow:0 24px 44px rgba(0,0,0,.5)}
+    .sidebar-launcher.is-open{background:var(--btn);color:var(--btn-ink);border-color:var(--ghost-hover-border);box-shadow:0 10px 24px rgba(15,23,42,.25)}
     .sidebar-launcher.is-open:hover,.sidebar-launcher.is-open:focus-visible{background:#ffa24d}
     body.sidebar-expanded .sidebar-launcher{left:220px}
-    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:var(--card-bg);border-right:1px solid var(--border);box-shadow:20px 0 40px rgba(0,0,0,.35);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:transform .3s ease,box-shadow .3s ease;overflow:hidden;transform:translateX(-100%)}
+    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:linear-gradient(180deg,#ffffff 0%,#f3f6fb 100%);border-right:1px solid var(--border);box-shadow:12px 0 28px rgba(15,23,42,.14);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:transform .3s ease,box-shadow .3s ease;overflow:hidden;transform:translateX(-100%)}
     .sidebar.pinned,.sidebar.peek{transform:translateX(0)}
-    .sidebar.pinned,.sidebar.peek{box-shadow:24px 0 44px rgba(0,0,0,.4)}
+    .sidebar.pinned,.sidebar.peek{box-shadow:16px 0 30px rgba(15,23,42,.16)}
     .sidebar .sidebar-content{position:relative;height:100%;overflow-y:auto;padding-right:6px}
     .sidebar .label{transition:opacity .2s ease}
     .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
     .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);box-shadow:var(--ghost-inner-shadow)}
-    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.35)}
-    .btn:hover,.btn:focus-visible{box-shadow:0 14px 28px rgba(5,9,15,.45);transform:translateY(-1px)}
-    .btn:active{transform:translateY(0);box-shadow:0 6px 12px rgba(5,9,15,.6)}
+    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 8px 18px rgba(242,138,45,.28)}
+    .btn:hover,.btn:focus-visible{box-shadow:0 10px 20px rgba(15,23,42,.22);transform:translateY(-1px)}
+    .btn:active{transform:translateY(0);box-shadow:0 4px 12px rgba(15,23,42,.2)}
     .btn.ghost:hover,.btn.ghost:focus-visible{background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
     .btn.ghost:active{background:var(--ghost-active-bg);border-color:var(--ghost-active-border)}
     .btn.primary:hover,.btn.primary:focus-visible{background:#ffa24d}
@@ -171,16 +169,16 @@
     .center .service-group{display:flex;align-items:center;gap:8px;flex:0 1 auto;justify-content:flex-start}
     .center .service-group .label{color:var(--ink);font-weight:700;letter-spacing:.08em;text-transform:uppercase;font-size:14px}
     .center .service-group select{flex:1 1 240px;min-width:200px}
-    .addserv{border:1px solid var(--addserv-border);background:var(--addserv-bg);color:var(--addserv-ink);width:44px;height:44px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;line-height:1;cursor:pointer;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;box-shadow:0 12px 28px rgba(5,9,15,.35)}
-    .addserv:hover,.addserv:focus-visible{background:var(--addserv-hover-bg);border-color:var(--addserv-hover-border);box-shadow:0 16px 32px rgba(5,9,15,.38);transform:translateY(-1px)}
-    .addserv:active{background:var(--addserv-active-bg);border-color:var(--addserv-active-border);transform:translateY(0);box-shadow:0 10px 22px rgba(5,9,15,.5)}
+    .addserv{border:1px solid var(--addserv-border);background:var(--addserv-bg);color:var(--addserv-ink);width:44px;height:44px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;font-size:22px;font-weight:700;line-height:1;cursor:pointer;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;box-shadow:0 8px 18px rgba(15,23,42,.22)}
+    .addserv:hover,.addserv:focus-visible{background:var(--addserv-hover-bg);border-color:var(--addserv-hover-border);box-shadow:0 12px 22px rgba(15,23,42,.26);transform:translateY(-1px)}
+    .addserv:active{background:var(--addserv-active-bg);border-color:var(--addserv-active-border);transform:translateY(0);box-shadow:0 6px 16px rgba(15,23,42,.24)}
     .addserv:focus-visible{outline:2px solid rgba(125,211,252,.55);outline-offset:2px}
     .addserv.remove{border-color:rgba(251,113,133,.45);color:#fecdd3;background:rgba(248,113,113,.18)}
     .addserv.remove:hover,.addserv.remove:focus-visible{background:rgba(248,113,113,.26);border-color:rgba(251,113,133,.55)}
     .addserv.remove:active{background:rgba(248,113,113,.32);border-color:rgba(251,113,133,.65)}
 
     /* ===== Form (labels arriba) ===== */
-    .form{background:var(--card-bg);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);backdrop-filter:blur(22px)}
+    .form{background:linear-gradient(180deg,#ffffff 0%,#f5f7fb 100%);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow)}
     .form-grid{display:grid;gap:16px}
     @media(min-width:720px){
       .form-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
@@ -196,7 +194,7 @@
     .actions{display:flex;justify-content:center;gap:10px;margin-top:18px;flex-wrap:wrap}
     .actions .btn{flex:1 1 140px}
     .small{font-size:12px;color:var(--muted);text-align:center;margin-top:8px}
-    .side-card{background:var(--card-bg);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);backdrop-filter:blur(22px);display:flex;flex-direction:column;gap:18px}
+    .side-card{background:linear-gradient(180deg,#ffffff 0%,#f5f8fc 100%);border-radius:20px;border:1px solid var(--border);padding:28px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:18px}
     .side-card h2{margin:0;font-size:18px;color:var(--ink);font-weight:700}
     .side-card p{margin:0;color:var(--muted);font-size:14px}
     .side-card .actions{flex-direction:column;justify-content:flex-start}
@@ -265,7 +263,7 @@
     }
     .table-header h2{margin:0;font-size:22px;font-weight:700;color:var(--ink);text-shadow:0 10px 20px rgba(0,0,0,.35)}
     .table-header p{margin:0;color:var(--muted);font-size:14px}
-    .table-card{position:relative;background:var(--table-card-bg);border-radius:20px;border:1px solid var(--border);box-shadow:var(--shadow);overflow:visible;backdrop-filter:blur(18px)}
+    .table-card{position:relative;background:linear-gradient(180deg,#ffffff 0%,#f2f5fa 100%);border-radius:20px;border:1px solid var(--border);box-shadow:var(--shadow);overflow:visible}
     .table-scroll{position:relative;width:100%;overflow-x:auto;overscroll-behavior-x:contain;-webkit-overflow-scrolling:touch;scrollbar-width:thin;scrollbar-color:rgba(125,211,252,.6) transparent;scrollbar-gutter:stable both-edges}
     .table-scroll:focus-visible{outline:2px solid rgba(125,211,252,.45);outline-offset:4px}
     .table-scroll::-webkit-scrollbar{height:10px}
@@ -290,9 +288,9 @@
       #tabla{display:block}
       #tabla thead{display:none}
       #tabla tbody{display:grid;gap:16px;padding:4px 0}
-      #tabla tbody tr{display:grid;grid-template-columns:1fr;gap:12px;padding:18px;border-radius:18px;border:1px solid var(--table-border);background:var(--table-card-bg);box-shadow:0 18px 32px rgba(5,9,15,.35)}
+      #tabla tbody tr{display:grid;grid-template-columns:1fr;gap:12px;padding:18px;border-radius:18px;border:1px solid var(--table-border);background:var(--table-card-bg);box-shadow:0 8px 18px rgba(15,23,42,.18)}
       #tabla tbody tr:nth-child(even){background:var(--table-card-bg)}
-      #tabla tbody tr:hover{background:var(--table-row-hover-bg);box-shadow:0 22px 38px rgba(5,9,15,.45)}
+      #tabla tbody tr:hover{background:var(--table-row-hover-bg);box-shadow:0 10px 22px rgba(15,23,42,.22)}
       #tabla tbody tr td{display:grid;gap:6px;padding:0;border:0;background:transparent;text-align:left}
       #tabla tbody tr td::before{content:attr(data-label);font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
       #tabla tbody tr td[data-label=""]::before{content:'';display:none}
@@ -309,7 +307,7 @@
       #tabla tbody tr td{display:table-cell;padding:14px 16px}
       #tabla tbody tr td::before{display:none}
     }
-    .tag{font-size:12px;padding:4px 10px;border-radius:999px;display:inline-block;border:1px solid var(--tag-border);background:var(--tag-bg);color:var(--ink);backdrop-filter:blur(12px)}
+    .tag{font-size:12px;padding:4px 10px;border-radius:999px;display:inline-block;border:1px solid var(--tag-border);background:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 100%);color:var(--ink)}
     .tag.ok{color:var(--ok);background:rgba(74,222,128,.16);border-color:rgba(74,222,128,.38)}
     .tag.warn{color:var(--warn);background:rgba(251,191,36,.16);border-color:rgba(251,191,36,.38)}
     .tag.bad{color:var(--bad);background:rgba(251,113,133,.2);border-color:rgba(251,113,133,.4)}
@@ -318,7 +316,7 @@
     .menu-wrap{position:relative;display:inline-flex;align-items:center;gap:8px}
     .row-menu-indicator{border:1px solid var(--ghost-border);background:var(--ghost);border-radius:12px;padding:6px 10px;line-height:1;color:var(--ink-soft);font-size:18px;letter-spacing:2px;transition:background-color .2s ease,border-color .2s ease,color .2s ease;user-select:none}
     tr[aria-expanded="true"] .row-menu-indicator{background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border);color:var(--ink)}
-    .menu{position:absolute;right:0;top:calc(100% + 8px);background:var(--menu-bg);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow);min-width:180px;padding:8px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-6px);transition:opacity .2s ease,transform .2s ease;z-index:50;backdrop-filter:blur(18px)}
+    .menu{position:absolute;right:0;top:calc(100% + 8px);background:linear-gradient(180deg,#ffffff 0%,#f3f6fb 100%);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow);min-width:180px;padding:8px;opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-6px);transition:opacity .2s ease,transform .2s ease;z-index:50}
     .menu.open{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
     .menu-item{display:block;width:100%;text-align:left;background:transparent;border:1px solid transparent;border-radius:10px;padding:10px 12px;cursor:pointer;font-size:14px;color:var(--ink);transition:background-color .15s ease,border-color .15s ease,color .15s ease}
     .menu-item:hover{background:var(--menu-hover-bg)}
@@ -326,20 +324,20 @@
     .menu-item.danger:hover{background:rgba(251,113,133,.2);border-color:rgba(251,113,133,.5)}
 
     /* ===== Modales ===== */
-    .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:16px;background:var(--backdrop-bg);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(6px);transition:opacity .2s ease,transform .2s ease;z-index:100;backdrop-filter:blur(12px)}
+    .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:16px;background:rgba(15,23,42,.32);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(6px);transition:opacity .2s ease,transform .2s ease;z-index:100}
     .modal-backdrop.open{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
-    .modal{background:var(--modal-bg);border:1px solid var(--border);border-radius:18px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column;box-shadow:var(--shadow);color:var(--ink);backdrop-filter:blur(22px)}
+    .modal{background:linear-gradient(180deg,#ffffff 0%,#f7f9fc 100%);border:1px solid var(--border);border-radius:18px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column;box-shadow:var(--shadow);color:var(--ink)}
     .modal header{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid var(--border)}
     .modal .body{padding:16px 18px;color:var(--ink)}
 
     /* ===== Chat (Gemini) ===== */
     .section-head{font-weight:700;margin-bottom:8px;color:var(--ink);text-shadow:0 10px 24px rgba(0,0,0,.45)}
-    .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:16px;padding:14px;background:var(--chat-log-bg);box-shadow:var(--surface-inner-shadow);backdrop-filter:blur(14px)}
+    .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:16px;padding:14px;background:linear-gradient(180deg,#f8fafc 0%,#eef2f6 100%);box-shadow:var(--surface-inner-shadow)}
     .chat-msg{margin:8px 0;display:flex}
     .chat-msg.user{justify-content:flex-end}
     .chat-msg .bubble{max-width:85%;padding:10px 12px;border-radius:12px;white-space:pre-wrap}
-    .chat-msg.user .bubble{background:linear-gradient(135deg,#f28a2d,#f59e0b);color:#1a1205;border:1px solid var(--ghost-border);box-shadow:0 14px 32px rgba(242,138,45,.35)}
-    .chat-msg.ai .bubble{background:var(--ai-bubble-bg);border:1px solid var(--ai-bubble-border);color:var(--ink);box-shadow:0 10px 24px rgba(0,0,0,.4)}
+    .chat-msg.user .bubble{background:linear-gradient(135deg,#f28a2d,#f59e0b);color:#1a1205;border:1px solid var(--ghost-border);box-shadow:0 8px 18px rgba(242,138,45,.28)}
+    .chat-msg.ai .bubble{background:var(--ai-bubble-bg);border:1px solid var(--ai-bubble-border);color:var(--ink);box-shadow:0 8px 18px rgba(15,23,42,.18)}
 
     /* ===== Tokens de tema ===== */
     .sidebar-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:16px}
@@ -367,7 +365,7 @@
     }
     @media(max-width:768px){
       .sidebar{box-shadow:0 0 0 rgba(0,0,0,0)}
-      .sidebar.pinned,.sidebar.peek{box-shadow:20px 0 40px rgba(0,0,0,.35)}
+      .sidebar.pinned,.sidebar.peek{box-shadow:12px 0 26px rgba(15,23,42,.16)}
       body.sidebar-expanded .sidebar-launcher{left:20px}
       .side-card .actions{flex-direction:column}
       .side-card .actions .btn{width:100%}

--- a/login.html
+++ b/login.html
@@ -30,37 +30,35 @@
     body{
       margin:0;
       min-height:100vh;
-      background:var(--bg);
       color:var(--ink);
       display:flex;
       align-items:center;
       justify-content:center;
       padding:48px 16px;
       position:relative;
+      background:radial-gradient(circle at 20% 20%,rgba(148,163,184,.18),rgba(0,0,0,0) 55%),
+        radial-gradient(circle at 80% 80%,rgba(59,130,246,.16),rgba(0,0,0,0) 60%),
+        #020617;
     }
     body::before{
       content:"";
       position:fixed;
       inset:-40%;
-      background:
-        linear-gradient(rgba(0,0,0,.78),rgba(0,0,0,.78)),
-        url("https://images.unsplash.com/photo-1524230572899-a752b3835840?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat fixed;
+      background:radial-gradient(circle at 15% 25%,rgba(37,99,235,.18),rgba(2,6,23,0) 55%),
+        radial-gradient(circle at 70% 75%,rgba(6,182,212,.14),rgba(2,6,23,0) 60%);
       pointer-events:none;
       z-index:-1;
-      filter:blur(12px);
-      transform:scale(1.06);
     }
     .login-shell{
       width:min(520px,100%);
       display:grid;
     }
     .landing-panel{
-      background:rgba(255,255,255,.06);
+      background:linear-gradient(180deg,rgba(15,23,42,.78) 0%,rgba(2,6,23,.9) 100%);
       border-radius:20px;
       border:1px solid var(--border);
       padding:32px;
-      box-shadow:0 30px 60px rgba(0,0,0,.55);
-      backdrop-filter:blur(22px);
+      box-shadow:0 8px 22px rgba(2,6,23,.45);
       display:grid;
       gap:20px;
     }
@@ -131,9 +129,9 @@
       border:1px solid var(--ghost-border);
       box-shadow:inset 0 1px 0 rgba(255,255,255,.05);
     }
-    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.35);}
-    .btn:hover,.btn:focus-visible{box-shadow:0 14px 28px rgba(5,9,15,.45);transform:translateY(-1px);}
-    .btn:active{transform:translateY(0);box-shadow:0 6px 12px rgba(5,9,15,.6);}
+    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 8px 18px rgba(242,138,45,.28);}
+    .btn:hover,.btn:focus-visible{box-shadow:0 10px 20px rgba(15,23,42,.32);transform:translateY(-1px);}
+    .btn:active{transform:translateY(0);box-shadow:0 4px 12px rgba(15,23,42,.28);}
     .btn:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none;}
     .linklike{
       background:none;

--- a/verify.html
+++ b/verify.html
@@ -28,37 +28,35 @@
     body{
       margin:0;
       min-height:100vh;
-      background:var(--bg);
       color:var(--ink);
       display:flex;
       align-items:center;
       justify-content:center;
       padding:48px 16px;
+      background:radial-gradient(circle at 25% 25%,rgba(96,165,250,.2),rgba(3,7,18,0) 55%),
+        radial-gradient(circle at 70% 75%,rgba(45,212,191,.16),rgba(3,7,18,0) 60%),
+        #030712;
     }
     body::before{
       content:"";
       position:fixed;
       inset:-40%;
-      background:
-        linear-gradient(rgba(3,7,18,.82),rgba(3,7,18,.82)),
-        url("https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80") center/cover no-repeat fixed;
+      background:radial-gradient(circle at 18% 20%,rgba(59,130,246,.18),rgba(3,7,18,0) 55%),
+        radial-gradient(circle at 82% 80%,rgba(14,165,233,.14),rgba(3,7,18,0) 60%);
       pointer-events:none;
       z-index:-1;
-      filter:blur(14px);
-      transform:scale(1.06);
     }
     main{
       width:min(480px,100%);
     }
     .panel{
-      background:var(--panel);
+      background:linear-gradient(180deg,rgba(15,23,42,.85) 0%,rgba(3,7,18,.92) 100%);
       border:1px solid var(--panel-border);
       border-radius:22px;
       padding:32px;
       display:grid;
       gap:20px;
-      box-shadow:0 30px 60px rgba(15,23,42,.58);
-      backdrop-filter:blur(18px);
+      box-shadow:0 10px 26px rgba(3,7,18,.46);
     }
     h1{margin:0;font-size:28px;}
     p{margin:0;color:var(--muted);line-height:1.5;}
@@ -84,9 +82,9 @@
       font-weight:600;
       transition:background-color .2s ease,transform .2s ease,box-shadow .2s ease;
     }
-    .primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.32);}
+    .primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 8px 18px rgba(242,138,45,.28);}
     .ghost{background:var(--ghost);color:var(--ink);border:1px solid var(--ghost-border);}
-    button:hover:not(:disabled),button:focus-visible:not(:disabled){transform:translateY(-1px);box-shadow:0 14px 24px rgba(5,9,15,.45);}
+    button:hover:not(:disabled),button:focus-visible:not(:disabled){transform:translateY(-1px);box-shadow:0 10px 20px rgba(15,23,42,.32);}
     button:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none;}
     @media(max-width:520px){
       body{padding:36px 14px;}


### PR DESCRIPTION
## Summary
- replace blurred glassmorphism panels with soft gradient surfaces across the landing page and dashboard chrome
- lighten box shadows on interactive controls, tables, and overlays to reduce visual weight
- simplify login and verification backgrounds by removing expensive blur filters in favour of subtle gradients

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc77276584832e8ae3a52dc490ecb6