### PR TITLE
Refresca los formularios con la paleta clara

### DIFF
--- a/login.html
+++ b/login.html
@@ -18,12 +18,14 @@
   </script>
   <style>
     :root{
-      --bg:#000000; --ink:#f8fafc; --ink-soft:#d2d9e6; --muted:#9aa7bb;
-      --field:rgba(14,18,26,.85); --field-focus:rgba(20,26,36,.92); --border:rgba(255,255,255,.12);
-      --btn:#f28a2d; --btn-ink:#1c130a; --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.18);
-      --ghost-hover-bg:rgba(255,255,255,.12); --ghost-hover-border:rgba(255,255,255,.26);
-      --ghost-active-bg:rgba(255,255,255,.18); --ghost-active-border:rgba(255,255,255,.32);
-      --success:#16f2a6; --danger:#f97373; --focus:#7dd3fc;
+      color-scheme:light;
+      --bg:#f8fafc; --ink:#0f172a; --ink-soft:#1e293b; --muted:#475569;
+      --field:#ffffff; --field-focus:#f1f5f9; --border:rgba(148,163,184,.35);
+      --btn:#f28a2d; --btn-ink:#1c130a; --ghost:rgba(226,232,240,.82); --ghost-border:rgba(148,163,184,.5);
+      --ghost-hover-bg:rgba(148,163,184,.28); --ghost-hover-border:rgba(100,116,139,.5);
+      --ghost-active-bg:rgba(148,163,184,.36); --ghost-active-border:rgba(71,85,105,.55);
+      --success:#16f2a6; --danger:#f97373; --focus:rgba(37,99,235,.45);
+      --panel-shadow:0 20px 38px -24px rgba(15,23,42,.28);
       font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial;
     }
     *{box-sizing:border-box;font-family:inherit;}
@@ -36,29 +38,21 @@
       justify-content:center;
       padding:48px 16px;
       position:relative;
-      background:radial-gradient(circle at 20% 20%,rgba(148,163,184,.18),rgba(0,0,0,0) 55%),
-        radial-gradient(circle at 80% 80%,rgba(59,130,246,.16),rgba(0,0,0,0) 60%),
-        #020617;
-    }
-    body::before{
-      content:"";
-      position:fixed;
-      inset:-40%;
-      background:radial-gradient(circle at 15% 25%,rgba(37,99,235,.18),rgba(2,6,23,0) 55%),
-        radial-gradient(circle at 70% 75%,rgba(6,182,212,.14),rgba(2,6,23,0) 60%);
-      pointer-events:none;
-      z-index:-1;
+      background:
+        radial-gradient(circle at 20% 20%,rgba(191,219,254,.35),rgba(191,219,254,0) 52%),
+        radial-gradient(circle at 78% 18%,rgba(148,163,184,.24),rgba(148,163,184,0) 58%),
+        linear-gradient(180deg,#f8fafc 0%,#e2e8f0 100%);
     }
     .login-shell{
       width:min(520px,100%);
       display:grid;
     }
     .landing-panel{
-      background:linear-gradient(180deg,rgba(15,23,42,.78) 0%,rgba(2,6,23,.9) 100%);
+      background:rgba(255,255,255,.92);
       border-radius:20px;
       border:1px solid var(--border);
       padding:32px;
-      box-shadow:0 8px 22px rgba(2,6,23,.45);
+      box-shadow:var(--panel-shadow);
       display:grid;
       gap:20px;
     }
@@ -69,7 +63,7 @@
     }
     .landing-panel header p{
       margin:8px 0 0;
-      color:var(--ink-soft);
+      color:var(--muted);
       line-height:1.5;
     }
     .landing-form{
@@ -91,7 +85,7 @@
     input:focus{
       outline:2px solid transparent;
       border-color:var(--focus);
-      box-shadow:0 0 0 4px rgba(125,211,252,.18);
+      box-shadow:0 0 0 4px rgba(37,99,235,.18);
       background:var(--field-focus);
     }
     .pin-wrap{position:relative;display:flex;align-items:center;}
@@ -127,11 +121,11 @@
       color:var(--ink);
       background:var(--ghost);
       border:1px solid var(--ghost-border);
-      box-shadow:inset 0 1px 0 rgba(255,255,255,.05);
+      box-shadow:inset 0 1px 0 rgba(255,255,255,.6);
     }
     .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 8px 18px rgba(242,138,45,.28);}
-    .btn:hover,.btn:focus-visible{box-shadow:0 10px 20px rgba(15,23,42,.32);transform:translateY(-1px);}
-    .btn:active{transform:translateY(0);box-shadow:0 4px 12px rgba(15,23,42,.28);}
+    .btn:hover,.btn:focus-visible{box-shadow:0 10px 20px rgba(15,23,42,.22);transform:translateY(-1px);}
+    .btn:active{transform:translateY(0);box-shadow:0 6px 14px rgba(15,23,42,.16);}
     .btn:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none;}
     .linklike{
       background:none;

--- a/verify.html
+++ b/verify.html
@@ -18,10 +18,12 @@
   </script>
   <style>
     :root{
-      --bg:#030712; --ink:#f8fafc; --ink-soft:#cbd5f5; --muted:#94a3b8;
-      --panel:rgba(15,23,42,.78); --panel-border:rgba(148,163,184,.2);
-      --btn:#f28a2d; --btn-ink:#1c130a; --ghost:rgba(255,255,255,.06); --ghost-border:rgba(255,255,255,.2);
-      --ghost-hover:rgba(255,255,255,.1); --success:#16f2a6; --danger:#f97373; --info:#7dd3fc;
+      color-scheme:light;
+      --bg:#f8fafc; --ink:#0f172a; --ink-soft:#1e293b; --muted:#475569;
+      --panel-bg:rgba(255,255,255,.94); --panel-border:rgba(148,163,184,.35);
+      --btn:#f28a2d; --btn-ink:#1c130a; --ghost:rgba(226,232,240,.82); --ghost-border:rgba(148,163,184,.5);
+      --ghost-hover:rgba(148,163,184,.28); --success:#16f2a6; --danger:#f97373; --info:#38bdf8;
+      --panel-shadow:0 22px 40px -26px rgba(15,23,42,.26);
       font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial;
     }
     *{box-sizing:border-box;font-family:inherit;}
@@ -33,30 +35,22 @@
       align-items:center;
       justify-content:center;
       padding:48px 16px;
-      background:radial-gradient(circle at 25% 25%,rgba(96,165,250,.2),rgba(3,7,18,0) 55%),
-        radial-gradient(circle at 70% 75%,rgba(45,212,191,.16),rgba(3,7,18,0) 60%),
-        #030712;
-    }
-    body::before{
-      content:"";
-      position:fixed;
-      inset:-40%;
-      background:radial-gradient(circle at 18% 20%,rgba(59,130,246,.18),rgba(3,7,18,0) 55%),
-        radial-gradient(circle at 82% 80%,rgba(14,165,233,.14),rgba(3,7,18,0) 60%);
-      pointer-events:none;
-      z-index:-1;
+      background:
+        radial-gradient(circle at 24% 18%,rgba(191,219,254,.35),rgba(191,219,254,0) 56%),
+        radial-gradient(circle at 78% 80%,rgba(148,163,184,.26),rgba(148,163,184,0) 60%),
+        linear-gradient(180deg,#f8fafc 0%,#e2e8f0 100%);
     }
     main{
       width:min(480px,100%);
     }
     .panel{
-      background:linear-gradient(180deg,rgba(15,23,42,.85) 0%,rgba(3,7,18,.92) 100%);
+      background:var(--panel-bg);
       border:1px solid var(--panel-border);
       border-radius:22px;
       padding:32px;
       display:grid;
       gap:20px;
-      box-shadow:0 10px 26px rgba(3,7,18,.46);
+      box-shadow:var(--panel-shadow);
     }
     h1{margin:0;font-size:28px;}
     p{margin:0;color:var(--muted);line-height:1.5;}
@@ -83,8 +77,8 @@
       transition:background-color .2s ease,transform .2s ease,box-shadow .2s ease;
     }
     .primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 8px 18px rgba(242,138,45,.28);}
-    .ghost{background:var(--ghost);color:var(--ink);border:1px solid var(--ghost-border);}
-    button:hover:not(:disabled),button:focus-visible:not(:disabled){transform:translateY(-1px);box-shadow:0 10px 20px rgba(15,23,42,.32);}
+    .ghost{background:var(--ghost);color:var(--ink);border:1px solid var(--ghost-border);box-shadow:inset 0 1px 0 rgba(255,255,255,.6);}
+    button:hover:not(:disabled),button:focus-visible:not(:disabled){transform:translateY(-1px);box-shadow:0 10px 20px rgba(15,23,42,.22);}
     button:disabled{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none;}
     @media(max-width:520px){
       body{padding:36px 14px;}


### PR DESCRIPTION
## Summary
- Actualicé las variables CSS de login y verificación para reutilizar la paleta clara del dashboard.
- Sustituí el fondo pseudoestático desenfocado por gradientes claros y retiré el pseudo-elemento body::before.
- Ajusté los paneles y controles para fondos traslúcidos suaves y sombras acordes al nuevo tema.

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc79187bf4832ebef9951dd4519577