### PR TITLE
Remove unused color variable

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,6 @@
   --color-background: #ffffff;
   --color-surface: transparent;
   --color-primary: #0057ff;
-  --color-primary-dark: #0040c1;
   --color-border: rgba(15, 23, 42, 0.08);
   --color-text: #111827;
   --color-text-secondary: #4b5563;


### PR DESCRIPTION
## Summary
- remove the unused `--color-primary-dark` custom property from the root theme definitions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc7e69ed30832e86dc021afbab39dc