### PR TITLE
Adjust sidebar transition to transform only

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
     .sidebar-launcher.is-open{background:var(--btn);color:var(--btn-ink);border-color:var(--ghost-hover-border);box-shadow:0 10px 24px rgba(15,23,42,.25)}
     .sidebar-launcher.is-open:hover,.sidebar-launcher.is-open:focus-visible{background:#ffa24d}
     body.sidebar-expanded .sidebar-launcher{left:220px}
-    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:linear-gradient(180deg,#ffffff 0%,#f3f6fb 100%);border-right:1px solid var(--border);box-shadow:12px 0 28px rgba(15,23,42,.14);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:transform .3s ease,box-shadow .3s ease;overflow:hidden;transform:translateX(-100%)}
+    .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:linear-gradient(180deg,#ffffff 0%,#f3f6fb 100%);border-right:1px solid var(--border);box-shadow:12px 0 28px rgba(15,23,42,.14);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:transform .3s ease;overflow:hidden;transform:translateX(-100%)}
     .sidebar.pinned,.sidebar.peek{transform:translateX(0)}
     .sidebar.pinned,.sidebar.peek{box-shadow:16px 0 30px rgba(15,23,42,.16)}
     .sidebar .sidebar-content{position:relative;height:100%;overflow-y:auto;padding-right:6px}


### PR DESCRIPTION
## Summary
- remove the box-shadow animation from the sidebar transition so it only animates its transform

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc808e620c832eb0ad78ab6f8e8454