### PR TITLE
Remove table row transition animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,6 @@
     th,td{padding:14px 16px;border-bottom:1px solid var(--table-border);font-size:14px;word-break:break-word;overflow-wrap:anywhere}
     th{text-align:left;color:var(--muted);font-weight:700;letter-spacing:.08em;font-size:12px;text-transform:uppercase}
     td{color:var(--ink);font-weight:500}
-    tbody tr{transition:background-color .2s ease,box-shadow .2s ease}
     tbody tr:nth-child(even){background:var(--table-row-alt-bg)}
     tbody tr:hover{background:var(--table-row-hover-bg);box-shadow:var(--table-row-hover-shadow)}
     thead th:first-child{border-top-left-radius:20px}


### PR DESCRIPTION
## Summary
- remove the transition animation from table rows so they no longer animate background or shadow changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc8a2297d4832e90078d97d975d5cf