### PR TITLE
Add theme color and PWA meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="theme-color" content="#f6f7fb" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b1420" media="(prefers-color-scheme: dark)">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="color-scheme" content="light dark" />
   <title>Zyl0</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/login.html
+++ b/login.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#f6f7fb" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b1420" media="(prefers-color-scheme: dark)">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="color-scheme" content="light dark" />
   <title>Iniciar sesión • Zyl0</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/verify.html
+++ b/verify.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#f6f7fb" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0b1420" media="(prefers-color-scheme: dark)">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="color-scheme" content="light dark" />
   <title>Verifica tu correo • Zyl0</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- add light and dark theme-color meta tags to index, login, and verify pages
- enable iOS web app capabilities via mobile web app meta tags on all HTML entry points

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9f425a84832e8209e15195cc1e58