### PR TITLE
Add background color variables for light and dark themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
   <style>
     :root{
       color-scheme:light;
+      --bg-light:#f6f7fb;
+      --bg-dark:#0b1420;
       --bg:#f8fafc;
       --card:#ffffff;
       --text:#0f172a;
@@ -128,6 +130,8 @@
     @media(prefers-color-scheme:dark){
       :root{
         color-scheme:dark;
+        --bg-light:#f6f7fb;
+        --bg-dark:#0b1420;
         --bg:#020617;
         --card:#111827;
         --text:#e2e8f0;
@@ -181,7 +185,8 @@
       --logo-highlight:color-mix(in srgb,var(--primary) 45%,var(--warn) 55%);
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
-    html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
+    html,body{margin:0;min-height:100%;background-color:var(--bg-light);background:var(--bg);color:var(--ink)}
+    @media(prefers-color-scheme:dark){html,body{background-color:var(--bg-dark)}}
     body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease}
     .landing{min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:40px;padding:48px 16px;text-align:center}
     .landing[hidden]{display:none}

--- a/login.html
+++ b/login.html
@@ -24,6 +24,8 @@
   <style>
     :root{
       color-scheme:light;
+      --bg-light:#f6f7fb;
+      --bg-dark:#0b1420;
       --bg:#f8fafc;
       --card:#ffffff;
       --text:#0f172a;
@@ -129,6 +131,8 @@
     @media(prefers-color-scheme:dark){
       :root{
         color-scheme:dark;
+        --bg-light:#f6f7fb;
+        --bg-dark:#0b1420;
         --bg:#020617;
         --card:#111827;
         --text:#e2e8f0;
@@ -182,6 +186,8 @@
       --logo-highlight:color-mix(in srgb,var(--primary) 45%,var(--warn) 55%);
     }
     *{box-sizing:border-box;font-family:inherit;}
+    html,body{background-color:var(--bg-light);}
+    @media(prefers-color-scheme:dark){html,body{background-color:var(--bg-dark);}}
     body{
       margin:0;
       min-height:100vh;
@@ -191,6 +197,7 @@
       justify-content:center;
       padding:48px 16px;
       position:relative;
+      background-color:var(--bg-light);
       background:
         radial-gradient(circle at 20% 20%,color-mix(in srgb,var(--accent) 28%,transparent),transparent 52%),
         radial-gradient(circle at 78% 18%,color-mix(in srgb,var(--muted) 24%,transparent),transparent 58%),

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,7 @@
 :root {
   color-scheme: light;
+  --bg-light: #f6f7fb;
+  --bg-dark: #0b1420;
   --bg: #f8fafc;
   --card: #ffffff;
   --text: #0f172a;
@@ -129,6 +131,8 @@
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
+    --bg-light: #f6f7fb;
+    --bg-dark: #0b1420;
     --bg: #020617;
     --card: #111827;
     --text: #e2e8f0;
@@ -143,6 +147,9 @@
     --success: #16f2a6;
     --danger: #fb7185;
     --logo-highlight: color-mix(in srgb, var(--primary) 45%, var(--warn) 55%);
+  }
+  html, body {
+    background-color: var(--bg-dark);
   }
 }
 
@@ -189,10 +196,16 @@ html[data-theme="dark"] {
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: var(--bg-light);
   background: var(--body-surface);
   display: grid;
   place-items: center;
   color: var(--ink);
+}
+
+html,
+body {
+  background-color: var(--bg-light);
 }
 
 .shell {

--- a/verify.html
+++ b/verify.html
@@ -24,6 +24,8 @@
   <style>
     :root{
       color-scheme:light;
+      --bg-light:#f6f7fb;
+      --bg-dark:#0b1420;
       --bg:#f8fafc;
       --card:#ffffff;
       --text:#0f172a;
@@ -129,6 +131,8 @@
     @media(prefers-color-scheme:dark){
       :root{
         color-scheme:dark;
+        --bg-light:#f6f7fb;
+        --bg-dark:#0b1420;
         --bg:#020617;
         --card:#111827;
         --text:#e2e8f0;
@@ -182,6 +186,8 @@
       --logo-highlight:color-mix(in srgb,var(--primary) 45%,var(--warn) 55%);
     }
     *{box-sizing:border-box;font-family:inherit;}
+    html,body{background-color:var(--bg-light);}
+    @media(prefers-color-scheme:dark){html,body{background-color:var(--bg-dark);}}
     body{
       margin:0;
       min-height:100vh;
@@ -190,6 +196,7 @@
       align-items:center;
       justify-content:center;
       padding:48px 16px;
+      background-color:var(--bg-light);
       background:
         radial-gradient(circle at 24% 18%,color-mix(in srgb,var(--accent) 28%,transparent),transparent 56%),
         radial-gradient(circle at 78% 80%,color-mix(in srgb,var(--muted) 26%,transparent),transparent 60%),


### PR DESCRIPTION
## Summary
- add shared --bg-light and --bg-dark variables to each page and the global stylesheet
- set html/body background-color defaults and dark-mode overrides without altering existing gradients

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc9fc0a1fc832eb0cb975980384c8c