### PR TITLE
Use system colors for theme tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,23 +23,25 @@
   </script>
   <style>
     :root{
-      color-scheme:light;
-      --bg:#f8fafc;
-      --card:#ffffff;
-      --text:#0f172a;
-      --muted:#475569;
+      color-scheme:light dark;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 96%,var(--ink) 4%);
+      --bg-dark:color-mix(in srgb,var(--bg) 12%,var(--ink) 88%);
+      --muted:color-mix(in srgb,var(--ink) 70%,var(--bg));
       --primary:#f28a2d;
       --accent:#1d4ed8;
 
-      --ink:var(--text);
-      --ink-soft:color-mix(in srgb,var(--text) 78%,var(--bg));
+      --ink-soft:color-mix(in srgb,var(--ink) 78%,var(--bg));
       --field:var(--card);
       --field-focus:color-mix(in srgb,var(--card) 88%,var(--bg));
       --border:color-mix(in srgb,var(--muted) 32%,transparent);
       --pill-bg:color-mix(in srgb,var(--accent) 14%,transparent);
       --pill-ink:var(--accent);
       --btn:var(--primary);
-      --btn-ink:#1c130a;
+      --btn-ink:color-mix(in srgb,var(--ink) 92%,var(--bg));
       --primary-hover:color-mix(in srgb,var(--primary) 92%,var(--card));
       --primary-active:color-mix(in srgb,var(--primary) 88%,var(--muted));
       --ghost:color-mix(in srgb,var(--card) 86%,var(--bg));
@@ -127,14 +129,13 @@
 
     @media(prefers-color-scheme:dark){
       :root{
-        color-scheme:dark;
-        --bg:#020617;
-        --card:#111827;
-        --text:#e2e8f0;
-        --muted:#94a3b8;
+        color-scheme:light dark;
+        --bg-light:color-mix(in srgb,var(--bg) 18%,var(--ink) 82%);
+        --bg-dark:color-mix(in srgb,var(--bg) 6%,var(--ink) 94%);
+        --muted:color-mix(in srgb,var(--ink) 55%,var(--bg));
         --primary:#f59e0b;
         --accent:#60a5fa;
-        --btn-ink:#1a1205;
+        --btn-ink:color-mix(in srgb,var(--bg) 80%,var(--ink) 20%);
         --ok:#34d399;
         --warn:#fbbf24;
         --bad:#fb7185;
@@ -147,31 +148,29 @@
 
     html[data-theme="light"]{
       color-scheme:light;
-      --bg:#f8fafc;
-      --card:#ffffff;
-      --text:#0f172a;
-      --muted:#475569;
-      --primary:#f28a2d;
-      --accent:#1d4ed8;
-      --btn-ink:#1c130a;
-      --ok:#4ade80;
-      --warn:#fbbf24;
-      --bad:#fb7185;
-      --link:#2563eb;
-      --success:#16f2a6;
-      --danger:#f97373;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 96%,var(--ink) 4%);
+      --bg-dark:color-mix(in srgb,var(--bg) 12%,var(--ink) 88%);
+      --muted:color-mix(in srgb,var(--ink) 70%,var(--bg));
+      --btn-ink:color-mix(in srgb,var(--ink) 92%,var(--bg));
       --logo-highlight:color-mix(in srgb,var(--primary) 55%,var(--warn) 45%);
     }
 
     html[data-theme="dark"]{
       color-scheme:dark;
-      --bg:#020617;
-      --card:#111827;
-      --text:#e2e8f0;
-      --muted:#94a3b8;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 18%,var(--ink) 82%);
+      --bg-dark:color-mix(in srgb,var(--bg) 6%,var(--ink) 94%);
+      --muted:color-mix(in srgb,var(--ink) 55%,var(--bg));
+      --btn-ink:color-mix(in srgb,var(--bg) 80%,var(--ink) 20%);
       --primary:#f59e0b;
       --accent:#60a5fa;
-      --btn-ink:#1a1205;
       --ok:#34d399;
       --warn:#fbbf24;
       --bad:#fb7185;

--- a/login.html
+++ b/login.html
@@ -23,23 +23,25 @@
   </script>
   <style>
     :root{
-      color-scheme:light;
-      --bg:#f8fafc;
-      --card:#ffffff;
-      --text:#0f172a;
-      --muted:#475569;
+      color-scheme:light dark;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 96%,var(--ink) 4%);
+      --bg-dark:color-mix(in srgb,var(--bg) 12%,var(--ink) 88%);
+      --muted:color-mix(in srgb,var(--ink) 70%,var(--bg));
       --primary:#f28a2d;
       --accent:#1d4ed8;
 
-      --ink:var(--text);
-      --ink-soft:color-mix(in srgb,var(--text) 78%,var(--bg));
+      --ink-soft:color-mix(in srgb,var(--ink) 78%,var(--bg));
       --field:var(--card);
       --field-focus:color-mix(in srgb,var(--card) 88%,var(--bg));
       --border:color-mix(in srgb,var(--muted) 32%,transparent);
       --pill-bg:color-mix(in srgb,var(--accent) 14%,transparent);
       --pill-ink:var(--accent);
       --btn:var(--primary);
-      --btn-ink:#1c130a;
+      --btn-ink:color-mix(in srgb,var(--ink) 92%,var(--bg));
       --primary-hover:color-mix(in srgb,var(--primary) 92%,var(--card));
       --primary-active:color-mix(in srgb,var(--primary) 88%,var(--muted));
       --ghost:color-mix(in srgb,var(--card) 86%,var(--bg));
@@ -128,14 +130,13 @@
 
     @media(prefers-color-scheme:dark){
       :root{
-        color-scheme:dark;
-        --bg:#020617;
-        --card:#111827;
-        --text:#e2e8f0;
-        --muted:#94a3b8;
+        color-scheme:light dark;
+        --bg-light:color-mix(in srgb,var(--bg) 18%,var(--ink) 82%);
+        --bg-dark:color-mix(in srgb,var(--bg) 6%,var(--ink) 94%);
+        --muted:color-mix(in srgb,var(--ink) 55%,var(--bg));
         --primary:#f59e0b;
         --accent:#60a5fa;
-        --btn-ink:#1a1205;
+        --btn-ink:color-mix(in srgb,var(--bg) 80%,var(--ink) 20%);
         --ok:#34d399;
         --warn:#fbbf24;
         --bad:#fb7185;
@@ -148,31 +149,29 @@
 
     html[data-theme="light"]{
       color-scheme:light;
-      --bg:#f8fafc;
-      --card:#ffffff;
-      --text:#0f172a;
-      --muted:#475569;
-      --primary:#f28a2d;
-      --accent:#1d4ed8;
-      --btn-ink:#1c130a;
-      --ok:#4ade80;
-      --warn:#fbbf24;
-      --bad:#fb7185;
-      --link:#2563eb;
-      --success:#16f2a6;
-      --danger:#f97373;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 96%,var(--ink) 4%);
+      --bg-dark:color-mix(in srgb,var(--bg) 12%,var(--ink) 88%);
+      --muted:color-mix(in srgb,var(--ink) 70%,var(--bg));
+      --btn-ink:color-mix(in srgb,var(--ink) 92%,var(--bg));
       --logo-highlight:color-mix(in srgb,var(--primary) 55%,var(--warn) 45%);
     }
 
     html[data-theme="dark"]{
       color-scheme:dark;
-      --bg:#020617;
-      --card:#111827;
-      --text:#e2e8f0;
-      --muted:#94a3b8;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 18%,var(--ink) 82%);
+      --bg-dark:color-mix(in srgb,var(--bg) 6%,var(--ink) 94%);
+      --muted:color-mix(in srgb,var(--ink) 55%,var(--bg));
+      --btn-ink:color-mix(in srgb,var(--bg) 80%,var(--ink) 20%);
       --primary:#f59e0b;
       --accent:#60a5fa;
-      --btn-ink:#1a1205;
       --ok:#34d399;
       --warn:#fbbf24;
       --bad:#fb7185;

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,23 @@
 :root {
-  color-scheme: light;
-  --bg-light: #f6f7fb;
-  --bg-dark: #0b1420;
-  --bg: #f8fafc;
-  --card: #ffffff;
-  --text: #0f172a;
-  --muted: #475569;
+  color-scheme: light dark;
+  --bg: Canvas;
+  --card: Canvas;
+  --text: CanvasText;
+  --ink: var(--text);
+  --bg-light: color-mix(in srgb, var(--bg) 96%, var(--ink) 4%);
+  --bg-dark: color-mix(in srgb, var(--bg) 12%, var(--ink) 88%);
+  --muted: color-mix(in srgb, var(--ink) 70%, var(--bg));
   --primary: #f28a2d;
   --accent: #1d4ed8;
 
-  --ink: var(--text);
-  --ink-soft: color-mix(in srgb, var(--text) 78%, var(--bg));
+  --ink-soft: color-mix(in srgb, var(--ink) 78%, var(--bg));
   --field: var(--card);
   --field-focus: color-mix(in srgb, var(--card) 88%, var(--bg));
   --border: color-mix(in srgb, var(--muted) 32%, transparent);
   --pill-bg: color-mix(in srgb, var(--accent) 14%, transparent);
   --pill-ink: var(--accent);
   --btn: var(--primary);
-  --btn-ink: #1c130a;
+  --btn-ink: color-mix(in srgb, var(--ink) 92%, var(--bg));
   --primary-hover: color-mix(in srgb, var(--primary) 92%, var(--card));
   --primary-active: color-mix(in srgb, var(--primary) 88%, var(--muted));
   --ghost: color-mix(in srgb, var(--card) 86%, var(--bg));
@@ -130,16 +130,13 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    color-scheme: dark;
-    --bg-light: #f6f7fb;
-    --bg-dark: #0b1420;
-    --bg: #020617;
-    --card: #111827;
-    --text: #e2e8f0;
-    --muted: #94a3b8;
+    color-scheme: light dark;
+    --bg-light: color-mix(in srgb, var(--bg) 18%, var(--ink) 82%);
+    --bg-dark: color-mix(in srgb, var(--bg) 6%, var(--ink) 94%);
+    --muted: color-mix(in srgb, var(--ink) 55%, var(--bg));
     --primary: #f59e0b;
     --accent: #60a5fa;
-    --btn-ink: #1a1205;
+    --btn-ink: color-mix(in srgb, var(--bg) 80%, var(--ink) 20%);
     --ok: #34d399;
     --warn: #fbbf24;
     --bad: #fb7185;
@@ -155,31 +152,29 @@
 
 html[data-theme="light"] {
   color-scheme: light;
-  --bg: #f8fafc;
-  --card: #ffffff;
-  --text: #0f172a;
-  --muted: #475569;
-  --primary: #f28a2d;
-  --accent: #1d4ed8;
-  --btn-ink: #1c130a;
-  --ok: #4ade80;
-  --warn: #fbbf24;
-  --bad: #fb7185;
-  --link: #2563eb;
-  --success: #16f2a6;
-  --danger: #f97373;
+  --bg: Canvas;
+  --card: Canvas;
+  --text: CanvasText;
+  --ink: var(--text);
+  --bg-light: color-mix(in srgb, var(--bg) 96%, var(--ink) 4%);
+  --bg-dark: color-mix(in srgb, var(--bg) 12%, var(--ink) 88%);
+  --muted: color-mix(in srgb, var(--ink) 70%, var(--bg));
+  --btn-ink: color-mix(in srgb, var(--ink) 92%, var(--bg));
   --logo-highlight: color-mix(in srgb, var(--primary) 55%, var(--warn) 45%);
 }
 
 html[data-theme="dark"] {
   color-scheme: dark;
-  --bg: #020617;
-  --card: #111827;
-  --text: #e2e8f0;
-  --muted: #94a3b8;
+  --bg: Canvas;
+  --card: Canvas;
+  --text: CanvasText;
+  --ink: var(--text);
+  --bg-light: color-mix(in srgb, var(--bg) 18%, var(--ink) 82%);
+  --bg-dark: color-mix(in srgb, var(--bg) 6%, var(--ink) 94%);
+  --muted: color-mix(in srgb, var(--ink) 55%, var(--bg));
+  --btn-ink: color-mix(in srgb, var(--bg) 80%, var(--ink) 20%);
   --primary: #f59e0b;
   --accent: #60a5fa;
-  --btn-ink: #1a1205;
   --ok: #34d399;
   --warn: #fbbf24;
   --bad: #fb7185;

--- a/verify.html
+++ b/verify.html
@@ -23,23 +23,25 @@
   </script>
   <style>
     :root{
-      color-scheme:light;
-      --bg:#f8fafc;
-      --card:#ffffff;
-      --text:#0f172a;
-      --muted:#475569;
+      color-scheme:light dark;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 96%,var(--ink) 4%);
+      --bg-dark:color-mix(in srgb,var(--bg) 12%,var(--ink) 88%);
+      --muted:color-mix(in srgb,var(--ink) 70%,var(--bg));
       --primary:#f28a2d;
       --accent:#1d4ed8;
 
-      --ink:var(--text);
-      --ink-soft:color-mix(in srgb,var(--text) 78%,var(--bg));
+      --ink-soft:color-mix(in srgb,var(--ink) 78%,var(--bg));
       --field:var(--card);
       --field-focus:color-mix(in srgb,var(--card) 88%,var(--bg));
       --border:color-mix(in srgb,var(--muted) 32%,transparent);
       --pill-bg:color-mix(in srgb,var(--accent) 14%,transparent);
       --pill-ink:var(--accent);
       --btn:var(--primary);
-      --btn-ink:#1c130a;
+      --btn-ink:color-mix(in srgb,var(--ink) 92%,var(--bg));
       --primary-hover:color-mix(in srgb,var(--primary) 92%,var(--card));
       --primary-active:color-mix(in srgb,var(--primary) 88%,var(--muted));
       --ghost:color-mix(in srgb,var(--card) 86%,var(--bg));
@@ -128,14 +130,13 @@
 
     @media(prefers-color-scheme:dark){
       :root{
-        color-scheme:dark;
-        --bg:#020617;
-        --card:#111827;
-        --text:#e2e8f0;
-        --muted:#94a3b8;
+        color-scheme:light dark;
+        --bg-light:color-mix(in srgb,var(--bg) 18%,var(--ink) 82%);
+        --bg-dark:color-mix(in srgb,var(--bg) 6%,var(--ink) 94%);
+        --muted:color-mix(in srgb,var(--ink) 55%,var(--bg));
         --primary:#f59e0b;
         --accent:#60a5fa;
-        --btn-ink:#1a1205;
+        --btn-ink:color-mix(in srgb,var(--bg) 80%,var(--ink) 20%);
         --ok:#34d399;
         --warn:#fbbf24;
         --bad:#fb7185;
@@ -148,31 +149,29 @@
 
     html[data-theme="light"]{
       color-scheme:light;
-      --bg:#f8fafc;
-      --card:#ffffff;
-      --text:#0f172a;
-      --muted:#475569;
-      --primary:#f28a2d;
-      --accent:#1d4ed8;
-      --btn-ink:#1c130a;
-      --ok:#4ade80;
-      --warn:#fbbf24;
-      --bad:#fb7185;
-      --link:#2563eb;
-      --success:#16f2a6;
-      --danger:#f97373;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 96%,var(--ink) 4%);
+      --bg-dark:color-mix(in srgb,var(--bg) 12%,var(--ink) 88%);
+      --muted:color-mix(in srgb,var(--ink) 70%,var(--bg));
+      --btn-ink:color-mix(in srgb,var(--ink) 92%,var(--bg));
       --logo-highlight:color-mix(in srgb,var(--primary) 55%,var(--warn) 45%);
     }
 
     html[data-theme="dark"]{
       color-scheme:dark;
-      --bg:#020617;
-      --card:#111827;
-      --text:#e2e8f0;
-      --muted:#94a3b8;
+      --bg:Canvas;
+      --card:Canvas;
+      --text:CanvasText;
+      --ink:var(--text);
+      --bg-light:color-mix(in srgb,var(--bg) 18%,var(--ink) 82%);
+      --bg-dark:color-mix(in srgb,var(--bg) 6%,var(--ink) 94%);
+      --muted:color-mix(in srgb,var(--ink) 55%,var(--bg));
+      --btn-ink:color-mix(in srgb,var(--bg) 80%,var(--ink) 20%);
       --primary:#f59e0b;
       --accent:#60a5fa;
-      --btn-ink:#1a1205;
       --ok:#34d399;
       --warn:#fbbf24;
       --bad:#fb7185;


### PR DESCRIPTION
## Summary
- switch the base theme tokens in the global styles and inline fallbacks to use Canvas and CanvasText
- recalculate ink and surface derived variables with color-mix so light and dark modes follow system colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca6ffbf90832ebd2fd862e1a45b54