### PR TITLE
Add display name capture and user profile sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,6 +559,10 @@
         </header>
         <form id="signupForm" class="landing-form">
           <div class="row">
+            <label for="signupName">Nombre para mostrar</label>
+            <input id="signupName" type="text" autocomplete="name" placeholder="Tu nombre o marca" required>
+          </div>
+          <div class="row">
             <label for="signupEmail">Correo</label>
             <input id="signupEmail" type="email" autocomplete="email" placeholder="tucorreo@empresa.com" required>
           </div>
@@ -840,7 +844,8 @@ import {
   signInWithPopup,
   sendPasswordResetEmail,
   signOut,
-  sendEmailVerification
+  sendEmailVerification,
+  updateProfile
 } from 'firebase/auth';
 import {
   collection,
@@ -889,12 +894,69 @@ const landingStartBtn=document.getElementById('landingStart');
 const landingLoginBtn=document.getElementById('landingLogin');
 const landingBackButtons=document.querySelectorAll('[data-landing-back]');
 const signupForm=document.getElementById('signupForm');
+const signupNameEl=document.getElementById('signupName');
 const signupEmailEl=document.getElementById('signupEmail');
 const signupPassEl=document.getElementById('signupPass');
 const signupConfirmEl=document.getElementById('signupConfirm');
 const signupErrorEl=document.getElementById('signupError');
 const loginForm=document.getElementById('loginForm');
 const googleFeedbackEl=document.querySelector('[data-google-feedback]');
+
+function hashString(value=''){
+  let hash=0;
+  for(let i=0;i<value.length;i+=1){
+    hash=(hash<<5)-hash+value.charCodeAt(i);
+    hash|=0;
+  }
+  return Math.abs(hash);
+}
+function generateAvatarColor(seed){
+  const hash=hashString(seed||'default');
+  const hue=hash%360;
+  return `hsl(${hue}, 65%, 55%)`;
+}
+function getDefaultLanguage(){
+  if(typeof navigator!=='undefined'){
+    return navigator.language || navigator.userLanguage || 'es';
+  }
+  return 'es';
+}
+function getCurrentThemePreference(){
+  const themeAttr=document.documentElement?.dataset?.theme;
+  if(themeAttr&&themeAttr.trim()){ return themeAttr.trim(); }
+  return 'system';
+}
+async function syncUserProfile(user, { displayName }={}){
+  if(!user) return null;
+  const requestedName=(displayName||'').trim();
+  let finalDisplayName=requestedName||(user.displayName||'').trim();
+  if(!finalDisplayName){
+    finalDisplayName=user.email?user.email.split('@')[0]:'Usuario';
+  }
+  const shouldUpdateProfile=finalDisplayName&&user.displayName!==finalDisplayName;
+  if(shouldUpdateProfile){
+    try{
+      await updateProfile(user, { displayName: finalDisplayName });
+    }catch(error){
+      console.error('No se pudo actualizar el perfil del usuario', error);
+    }
+  }
+  const avatarSeed=user.uid||user.email||finalDisplayName;
+  const avatarColor=generateAvatarColor(String(avatarSeed));
+  const language=getDefaultLanguage();
+  const theme=getCurrentThemePreference();
+  const userDocRef=doc(firestore, 'users', user.uid);
+  const payload={
+    displayName: finalDisplayName,
+    email: user.email||'',
+    avatarColor,
+    language,
+    theme,
+    updatedAt: serverTimestamp()
+  };
+  await setDoc(userDocRef, payload, { merge: true });
+  return payload;
+}
 
 function setLandingView(view){
   landingPanels.forEach(panel=>{
@@ -905,7 +967,7 @@ function setLandingView(view){
   if(view==='login'){
     setTimeout(()=>authEmailEl?.focus(),0);
   }else if(view==='signup'){
-    setTimeout(()=>signupEmailEl?.focus(),0);
+    setTimeout(()=>signupNameEl?.focus(),0);
   }
 }
 
@@ -1561,6 +1623,13 @@ async function syncLocalServicesToCloudIfEmpty(){
 }
 async function updateUserState(user){
   currentUser = user;
+  if(user){
+    try{
+      await syncUserProfile(user);
+    }catch(error){
+      console.error('No se pudo sincronizar el perfil del usuario', error);
+    }
+  }
   await handleClientStorageForUser(user);
   if(user){
     hideLanding();
@@ -1610,6 +1679,7 @@ async function signInWithGoogle({ feedbackEl = googleFeedbackEl }={}){
   if(feedbackEl){ setFeedback(feedbackEl, 'Abriendo Google…', 'info'); }
   try{
     const credential = await signInWithPopup(auth, googleProvider);
+    await syncUserProfile(credential.user);
     if(feedbackEl){ setFeedback(feedbackEl, 'Sesión iniciada con Google.', 'success'); }
     return credential;
   }catch(error){
@@ -1639,9 +1709,11 @@ if(googleButtonContainer){
 signupForm?.addEventListener('submit', async (event)=>{
   event.preventDefault();
   signupErrorEl.textContent='';
+  const displayName=(signupNameEl.value||'').trim();
   const email=(signupEmailEl.value||'').trim();
   const pass=(signupPassEl.value||'').trim();
   const confirm=(signupConfirmEl.value||'').trim();
+  if(!displayName){ signupErrorEl.textContent='Escribe tu nombre para mostrar.'; signupNameEl?.focus(); return; }
   if(!email||!pass){ signupErrorEl.textContent='Completa correo y contraseña.'; return; }
   if(pass.length<8){ signupErrorEl.textContent='La contraseña debe tener al menos 8 caracteres.'; return; }
   if(pass!==confirm){ signupErrorEl.textContent='Las contraseñas no coinciden.'; return; }
@@ -1649,6 +1721,8 @@ signupForm?.addEventListener('submit', async (event)=>{
   submitBtn.disabled=true; submitBtn.textContent='Creando cuenta…';
   try{
     const cred=await createUserWithEmailAndPassword(auth, email, pass);
+    await updateProfile(cred.user, { displayName });
+    await syncUserProfile(cred.user, { displayName });
     await sendEmailVerification(cred.user);
     signupErrorEl.textContent='';
     window.location.href='verify.html';


### PR DESCRIPTION
## Summary
- add a required display name field to the signup form and client-side validation
- update user creation logic to persist display name, deterministic avatar color, and metadata via updateProfile and Firestore
- run the same profile synchronization after Google sign-in and on auth state changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc3b132ec832e977e4cb3f2c76549