### PR TITLE
Add settings modal to user config menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,6 +463,15 @@
     .modal{background:var(--modal-grad);border:1px solid var(--border);border-radius:18px;width:min(760px,96vw);max-height:90vh;display:flex;flex-direction:column;box-shadow:var(--shadow);color:var(--ink)}
     .modal header{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid var(--border)}
     .modal .body{padding:16px 18px;color:var(--ink)}
+    .settings-description{margin:0 0 12px;color:var(--muted)}
+    .settings-fieldset{border:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
+    .settings-fieldset legend{font-weight:600;margin-bottom:4px}
+    .settings-group{display:flex;flex-direction:column;gap:8px}
+    .settings-option{display:flex;align-items:center;gap:12px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:var(--field);cursor:pointer;transition:background .2s ease,border-color .2s ease,box-shadow .2s ease}
+    .settings-option:hover{background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
+    .settings-option:focus-within{outline:2px solid var(--accent);outline-offset:2px}
+    .settings-option input{margin:0;accent-color:var(--accent)}
+    .settings-option span{flex:1}
 
     /* ===== Encabezados de sección ===== */
     .section-head{font-weight:700;margin-bottom:8px;color:var(--ink);text-shadow:0 10px 24px color-mix(in srgb,var(--text) 45%,transparent)}
@@ -642,7 +651,8 @@
                 <span class="sr-only">Abrir configuración</span>
               </button>
               <div class="auth-config-panel" id="userConfigPanel" hidden role="menu" aria-label="Configuración de usuario">
-                <button class="btn ghost label" id="btnLogout" type="button">Cerrar sesión</button>
+                <button class="btn ghost label" id="btnUserSettings" type="button">Configuración</button>
+                <button class="btn ghost label" id="btnLogout" type="button">Cerrar</button>
               </div>
             </div>
           </li>
@@ -777,6 +787,35 @@
     </section>
     </main>
   </div>
+  <!-- ===== Modal Configuración de usuario ===== -->
+  <div id="settingsModal" class="modal-backdrop" aria-hidden="true">
+    <div class="modal" role="dialog" aria-labelledby="settingsModalTitle">
+      <header>
+        <strong id="settingsModalTitle">Configuración</strong>
+        <button class="btn ghost" id="btnSettingsClose" type="button">Cerrar</button>
+      </header>
+      <div class="body">
+        <p class="settings-description">Personaliza tu experiencia ajustando las preferencias disponibles.</p>
+        <fieldset class="settings-fieldset">
+          <legend>Tema de la aplicación</legend>
+          <div class="settings-group">
+            <label class="settings-option">
+              <input type="radio" name="settingsTheme" value="system">
+              <span>Usar el modo del sistema</span>
+            </label>
+            <label class="settings-option">
+              <input type="radio" name="settingsTheme" value="light">
+              <span>Tema claro</span>
+            </label>
+            <label class="settings-option">
+              <input type="radio" name="settingsTheme" value="dark">
+              <span>Tema oscuro</span>
+            </label>
+          </div>
+        </fieldset>
+      </div>
+    </div>
+  </div>
 
   <!-- ===== Modal Correos enlazados ===== -->
   <div id="linkedModal" class="modal-backdrop" aria-hidden="true">
@@ -851,6 +890,64 @@ const persistenceReadyForInit = persistenceReady.catch(error => {
     toast('No se pudo activar el modo sin conexión.');
   }
 });
+
+const THEME_PREFERENCE_KEY = 'app_theme_preference';
+const VALID_THEME_PREFERENCES = new Set(['system','light','dark']);
+
+function readStoredThemePreference(){
+  try{
+    const stored = localStorage.getItem(THEME_PREFERENCE_KEY);
+    if(stored && VALID_THEME_PREFERENCES.has(stored)){
+      return stored;
+    }
+  }catch(error){
+    console.warn('No se pudo leer la preferencia de tema almacenada.', error);
+  }
+  return 'system';
+}
+
+function applyThemePreference(mode){
+  const root = document.documentElement;
+  if(!root) return;
+  if(mode==='light' || mode==='dark'){
+    root.dataset.theme = mode;
+  }else{
+    delete root.dataset.theme;
+  }
+}
+
+let currentThemePreference = readStoredThemePreference();
+const datasetThemePreference = document.documentElement?.dataset?.theme;
+if(datasetThemePreference && VALID_THEME_PREFERENCES.has(datasetThemePreference)){
+  currentThemePreference = datasetThemePreference;
+}
+applyThemePreference(currentThemePreference);
+
+function persistThemePreference(mode){
+  try{
+    localStorage.setItem(THEME_PREFERENCE_KEY, mode);
+  }catch(error){
+    console.warn('No se pudo guardar la preferencia de tema.', error);
+  }
+}
+
+let settingsThemeOptions = [];
+let settingsReturnFocus = null;
+
+function updateThemeControls(pref = currentThemePreference){
+  if(!Array.isArray(settingsThemeOptions) || !settingsThemeOptions.length) return;
+  settingsThemeOptions.forEach((input)=>{
+    input.checked = input.value === pref;
+  });
+}
+
+function setThemePreference(mode){
+  if(!VALID_THEME_PREFERENCES.has(mode)) return;
+  currentThemePreference = mode;
+  applyThemePreference(mode);
+  persistThemePreference(mode);
+  updateThemeControls(mode);
+}
 
 /* ===== helpers y refs ===== */
 const $=s=>document.querySelector(s);
@@ -1747,12 +1844,44 @@ const toggleAuthPass = document.getElementById('toggleAuthPass');
 const btnForgot    = document.getElementById('btnForgot');
 const googleButtonContainer = document.getElementById('googleButton');
 const btnUserMenu = document.getElementById('btnUserMenu');
+const btnUserSettings = document.getElementById('btnUserSettings');
 const userConfigPanel = document.getElementById('userConfigPanel');
 const authUserShell = document.getElementById('authUserShell');
+const settingsModal = document.getElementById('settingsModal');
+const btnSettingsClose = document.getElementById('btnSettingsClose');
+settingsThemeOptions = Array.from(document.querySelectorAll('input[name="settingsTheme"]'));
+updateThemeControls();
+settingsThemeOptions.forEach((input)=>{
+  input.addEventListener('change', ()=> setThemePreference(input.value));
+});
 
 btnAuthOpen?.addEventListener('click', ()=>{
   showLanding('login');
 });
+
+function openSettingsModal(){
+  if(!settingsModal) return;
+  settingsReturnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  settingsModal.classList.add('open');
+  settingsModal.setAttribute('aria-hidden','false');
+  updateThemeControls();
+  const focusTarget = settingsModal.querySelector('input[name="settingsTheme"]:checked') || settingsModal.querySelector('input[name="settingsTheme"]');
+  if(focusTarget && typeof focusTarget.focus === 'function'){
+    focusTarget.focus({ preventScroll:true });
+  }
+}
+
+function closeSettingsModal(){
+  if(!settingsModal) return;
+  if(!settingsModal.classList.contains('open')) return;
+  settingsModal.classList.remove('open');
+  settingsModal.setAttribute('aria-hidden','true');
+  const returnTarget = settingsReturnFocus;
+  settingsReturnFocus = null;
+  if(returnTarget && typeof returnTarget.focus === 'function'){
+    setTimeout(()=> returnTarget.focus({ preventScroll:true }),0);
+  }
+}
 
 btnUserMenu?.addEventListener('click', (event)=>{
   event.preventDefault();
@@ -1762,6 +1891,24 @@ btnUserMenu?.addEventListener('click', (event)=>{
   setUserConfigPanelState(shouldOpen);
 });
 
+btnUserSettings?.addEventListener('click', (event)=>{
+  event.preventDefault();
+  event.stopPropagation();
+  setUserConfigPanelState(false);
+  openSettingsModal();
+});
+
+btnSettingsClose?.addEventListener('click', (event)=>{
+  event.preventDefault();
+  closeSettingsModal();
+});
+
+settingsModal?.addEventListener('click', (event)=>{
+  if(event.target === settingsModal){
+    closeSettingsModal();
+  }
+});
+
 document.addEventListener('click', (event)=>{
   if(!userConfigPanel || userConfigPanel.hidden) return;
   if(authUserShell && authUserShell.contains(event.target)) return;
@@ -1769,7 +1916,13 @@ document.addEventListener('click', (event)=>{
 });
 
 document.addEventListener('keydown', (event)=>{
-  if(event.key === 'Escape' && !userConfigPanel?.hidden){
+  if(event.key !== 'Escape') return;
+  if(settingsModal?.classList.contains('open')){
+    event.preventDefault();
+    closeSettingsModal();
+    return;
+  }
+  if(!userConfigPanel?.hidden){
     setUserConfigPanelState(false);
   }
 });


### PR DESCRIPTION
## Summary
- add a new "Configuración" action inside the user menu and shorten the logout copy to "Cerrar"
- introduce a user settings modal with theme preference controls and supporting styles
- wire up the settings button to close the menu, open the modal, and keep Escape/blur handling intact

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcd0ca3c48832e85e8cd9748da0a46