### PR TITLE
Add aria-controls link for user menu trigger

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
           <li class="auth-controls">
             <button class="btn ghost label" id="btnAuthOpen">Acceder</button>
             <div class="auth-user" id="authUserShell" hidden aria-hidden="true">
-              <button type="button" class="auth-avatar-btn" id="btnUserMenu" aria-haspopup="true" aria-expanded="false">
+              <button type="button" class="auth-avatar-btn" id="btnUserMenu" aria-haspopup="true" aria-controls="userConfigPanel" aria-expanded="false">
                 <span class="auth-avatar" id="userAvatar" aria-hidden="true">U</span>
                 <span class="auth-name" id="userDisplayName"></span>
                 <span class="sr-only">Abrir configuración</span>


### PR DESCRIPTION
## Summary
- add aria-controls="userConfigPanel" to the authenticated user menu trigger button to link it with its panel
- verified that the existing setUserConfigPanelState helper still manages the aria-expanded attribute for the button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd66adc1e4832e91f4e70183eebbcd