### PR TITLE
Ensure user config panel toggles hidden attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1591,7 +1591,10 @@ function setUserConfigPanelState(open){
     panel.classList.add('hidden');
     trigger.setAttribute('aria-expanded', 'false');
   }
+  panel.toggleAttribute('hidden', !shouldOpen);
+  panel.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
 }
+setUserConfigPanelState(false);
 function authUpdateUI(profileData){
   const btnAuthOpen = document.getElementById('btnAuthOpen');
   const authUserShell = document.getElementById('authUserShell');


### PR DESCRIPTION
## Summary
- toggle the user config panel hidden and aria-hidden attributes alongside the existing class handling
- enforce the initial panel state by invoking setUserConfigPanelState(false) after its definition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd77452da4832eacb4c39948e67ea4