### PR TITLE
Remove WhatsApp icon from integrations modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -868,7 +868,6 @@
           <div class="whatsapp-card">
             <div class="whatsapp-card-main">
               <div class="whatsapp-card-header">
-                <img src="assets/whatsapp.svg" alt="WhatsApp" class="whatsapp-icon">
                 <div class="whatsapp-card-text">
                   <h3 class="whatsapp-title">WhatsApp</h3>
                   <p class="whatsapp-description">
@@ -881,7 +880,6 @@
               </div>
 
               <button id="connectWhatsappButton" class="btn primary whatsapp-connect-button" type="button">
-                <span class="whatsapp-connect-icon"></span>
                 <span class="whatsapp-connect-label">Conectar WhatsApp</span>
               </button>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -605,13 +605,6 @@ input:focus {
   gap: 12px;
 }
 
-.whatsapp-icon {
-  width: 16px;
-  height: 16px;
-  object-fit: contain;
-  flex-shrink: 0;
-}
-
 .whatsapp-card-text {
   display: flex;
   flex-direction: column;
@@ -642,20 +635,9 @@ input:focus {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
   border-radius: 999px;
   padding-inline: 24px;
   height: 40px;
-}
-
-.whatsapp-connect-icon {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background-image: url("assets/whatsapp.svg");
-  background-size: cover;
-  background-position: center;
 }
 
 .whatsapp-connect-label {


### PR DESCRIPTION
## Summary
- remove the WhatsApp graphic from the integrations modal layout
- clean up styles tied to the removed icons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69334c42aaf083339446fb13e118e6a0)